### PR TITLE
subsys: greybus: Use handler function instead of jumptable

### DIFF
--- a/include/greybus/greybus.h
+++ b/include/greybus/greybus.h
@@ -69,22 +69,15 @@ struct gb_operation;
 
 typedef void (*gb_operation_callback)(struct gb_operation *operation);
 typedef uint8_t (*gb_operation_handler_t)(struct gb_operation *operation);
-typedef void (*gb_operation_fast_handler_t)(unsigned int cport, void *data);
 
 #define GB_HANDLER(t, h)                                                                           \
 	{                                                                                          \
 		.type = t, .handler = h, .name = #h,                                               \
 	}
 
-#define GB_FAST_HANDLER(t, h)                                                                      \
-	{                                                                                          \
-		.type = t, .fast_handler = h, .name = #h,                                          \
-	}
-
 struct gb_operation_handler {
 	uint8_t type;
 	gb_operation_handler_t handler;
-	gb_operation_fast_handler_t fast_handler;
 	const char *name;
 };
 

--- a/include/greybus/greybus.h
+++ b/include/greybus/greybus.h
@@ -68,18 +68,7 @@ enum gb_event {
 struct gb_operation;
 
 typedef void (*gb_operation_callback)(struct gb_operation *operation);
-typedef uint8_t (*gb_operation_handler_t)(struct gb_operation *operation);
-
-#define GB_HANDLER(t, h)                                                                           \
-	{                                                                                          \
-		.type = t, .handler = h, .name = #h,                                               \
-	}
-
-struct gb_operation_handler {
-	uint8_t type;
-	gb_operation_handler_t handler;
-	const char *name;
-};
+typedef uint8_t (*gb_operation_handler_t)(uint8_t type, struct gb_operation *operation);
 
 struct gb_transport_backend {
 	void (*init)(void);
@@ -145,9 +134,8 @@ struct gb_driver {
 	void (*connected)(unsigned int cport);
 	void (*disconnected)(unsigned int cport);
 
-	struct gb_operation_handler *op_handlers;
+	gb_operation_handler_t op_handler;
 
-	size_t op_handlers_count;
 	const char *name;
 
 	struct gb_bundle *bundle;
@@ -197,11 +185,6 @@ static inline struct gb_operation *gb_operation_get_response_op(struct gb_operat
 static inline const char *gb_driver_name(struct gb_driver *driver)
 {
 	return driver->name;
-}
-
-static inline const char *gb_handler_name(struct gb_operation_handler *handler)
-{
-	return handler->name;
 }
 
 int gb_init(struct gb_transport_backend *transport);

--- a/subsys/greybus/audio.c
+++ b/subsys/greybus/audio.c
@@ -1656,35 +1656,57 @@ static void gb_audio_exit(unsigned int mgmt_cport, struct gb_bundle *bundle)
 	info->initialized = false;
 }
 
-static struct gb_operation_handler gb_audio_mgmt_handlers[] = {
-	GB_HANDLER(GB_AUDIO_TYPE_PROTOCOL_VERSION, gb_audio_protocol_version_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_GET_TOPOLOGY_SIZE, gb_audio_get_topology_size_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_GET_TOPOLOGY, gb_audio_get_topology_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_GET_CONTROL, gb_audio_get_control_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_SET_CONTROL, gb_audio_set_control_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_ENABLE_WIDGET, gb_audio_enable_widget_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_DISABLE_WIDGET, gb_audio_disable_widget_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_GET_PCM, gb_audio_get_pcm_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_SET_PCM, gb_audio_set_pcm_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_SET_TX_DATA_SIZE, gb_audio_set_tx_data_size_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_GET_TX_DELAY, gb_audio_get_tx_delay_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_ACTIVATE_TX, gb_audio_activate_tx_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_DEACTIVATE_TX, gb_audio_deactivate_tx_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_SET_RX_DATA_SIZE, gb_audio_set_rx_data_size_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_GET_RX_DELAY, gb_audio_get_rx_delay_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_ACTIVATE_RX, gb_audio_activate_rx_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_DEACTIVATE_RX, gb_audio_deactivate_rx_handler),
+static uint8_t gb_audio_mgmt_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_AUDIO_TYPE_PROTOCOL_VERSION:
+		return gb_audio_protocol_version_handler(opr);
+	case GB_AUDIO_TYPE_GET_TOPOLOGY_SIZE:
+		return gb_audio_get_topology_size_handler(opr);
+	case GB_AUDIO_TYPE_GET_TOPOLOGY:
+		return gb_audio_get_topology_handler(opr);
+	case GB_AUDIO_TYPE_GET_CONTROL:
+		return gb_audio_get_control_handler(opr);
+	case GB_AUDIO_TYPE_SET_CONTROL:
+		return gb_audio_set_control_handler(opr);
+	case GB_AUDIO_TYPE_ENABLE_WIDGET:
+		return gb_audio_enable_widget_handler(opr);
+	case GB_AUDIO_TYPE_DISABLE_WIDGET:
+		return gb_audio_disable_widget_handler(opr);
+	case GB_AUDIO_TYPE_GET_PCM:
+		return gb_audio_get_pcm_handler(opr);
+	case GB_AUDIO_TYPE_SET_PCM:
+		return gb_audio_set_pcm_handler(opr);
+	case GB_AUDIO_TYPE_SET_TX_DATA_SIZE:
+		return gb_audio_set_tx_data_size_handler(opr);
+	case GB_AUDIO_TYPE_GET_TX_DELAY:
+		return gb_audio_get_tx_delay_handler(opr);
+	case GB_AUDIO_TYPE_ACTIVATE_TX:
+		return gb_audio_deactivate_tx_handler(opr);
+	case GB_AUDIO_TYPE_DEACTIVATE_TX:
+		return gb_audio_deactivate_tx_handler(opr);
+	case GB_AUDIO_TYPE_SET_RX_DATA_SIZE:
+		return gb_audio_set_rx_data_size_handler(opr);
+	case GB_AUDIO_TYPE_GET_RX_DELAY:
+		return gb_audio_get_rx_delay_handler(opr);
+	case GB_AUDIO_TYPE_ACTIVATE_RX:
+		return gb_audio_activate_rx_handler(opr);
+	case GB_AUDIO_TYPE_DEACTIVATE_RX:
+		return gb_audio_deactivate_rx_handler(opr);
 	/* GB_AUDIO_TYPE_JACK_EVENT should only be received by the AP */
 	/* GB_AUDIO_TYPE_BUTTON_EVENT should only be received by the AP */
 	/* GB_AUDIO_TYPE_STREAMING_EVENT should only be received by the AP */
 	/* GB_AUDIO_TYPE_SEND_DATA should only be sent on a Data Connection */
-};
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 static struct gb_driver gb_audio_mgmt_driver = {
 	.init = gb_audio_init,
 	.exit = gb_audio_exit,
-	.op_handlers = gb_audio_mgmt_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_audio_mgmt_handlers),
+	.op_handler = gb_audio_mgmt_handler,
 };
 
 void gb_audio_mgmt_register(int mgmt_cport, int bundle)
@@ -1751,14 +1773,21 @@ static uint8_t gb_audio_send_data_handler(struct gb_operation *operation)
 	return GB_OP_SUCCESS;
 }
 
-static struct gb_operation_handler gb_audio_data_handlers[] = {
-	GB_HANDLER(GB_AUDIO_TYPE_PROTOCOL_VERSION, gb_audio_protocol_version_handler),
-	GB_HANDLER(GB_AUDIO_TYPE_SEND_DATA, gb_audio_send_data_handler),
-};
+static uint8_t gb_audio_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_AUDIO_TYPE_PROTOCOL_VERSION:
+		return gb_audio_protocol_version_handler(opr);
+	case GB_AUDIO_TYPE_SEND_DATA:
+		return gb_audio_send_data_handler(opr);
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 static struct gb_driver gb_audio_data_driver = {
-	.op_handlers = gb_audio_data_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_audio_data_handlers),
+	.op_handler = gb_audio_handler,
 };
 
 void gb_audio_data_register(int data_cport, int bundle)

--- a/subsys/greybus/camera.c
+++ b/subsys/greybus/camera.c
@@ -498,13 +498,24 @@ static void gb_camera_exit(unsigned int cport, struct gb_bundle *bundle)
 /**
  * @brief Greybus Camera Protocol operation handler
  */
-static struct gb_operation_handler gb_camera_handlers[] = {
-	GB_HANDLER(GB_CAMERA_TYPE_PROTOCOL_VERSION, gb_camera_protocol_version),
-	GB_HANDLER(GB_CAMERA_TYPE_CAPABILITIES, gb_camera_capabilities),
-	GB_HANDLER(GB_CAMERA_TYPE_CONFIGURE_STREAMS, gb_camera_configure_streams),
-	GB_HANDLER(GB_CAMERA_TYPE_CAPTURE, gb_camera_capture),
-	GB_HANDLER(GB_CAMERA_TYPE_FLUSH, gb_camera_flush),
-};
+static uint8_t gb_camera_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_CAMERA_TYPE_PROTOCOL_VERSION:
+		return gb_camera_protocol_version(opr);
+	case GB_CAMERA_TYPE_CAPABILITIES:
+		return gb_camera_capabilities(opr);
+	case GB_CAMERA_TYPE_CONFIGURE_STREAMS:
+		return gb_camera_configure_streams(opr);
+	case GB_CAMERA_TYPE_CAPTURE:
+		return gb_camera_capture(opr);
+	case GB_CAMERA_TYPE_FLUSH:
+		return gb_camera_flush(opr);
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 /**
  * @brief Greybus Camera Protocol driver ops
@@ -512,8 +523,7 @@ static struct gb_operation_handler gb_camera_handlers[] = {
 static struct gb_driver gb_camera_driver = {
 	.init = gb_camera_init,
 	.exit = gb_camera_exit,
-	.op_handlers = gb_camera_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_camera_handlers),
+	.op_handler = gb_camera_handler,
 };
 
 /**

--- a/subsys/greybus/control-gpb.c
+++ b/subsys/greybus/control-gpb.c
@@ -421,32 +421,54 @@ static uint8_t gb_control_timesync_get_last_event(struct gb_operation *operation
 	return gb_errno_to_op_result(retval);
 }
 
-static struct gb_operation_handler gb_control_handlers[] = {
-	GB_HANDLER(GB_CONTROL_TYPE_PROTOCOL_VERSION, gb_control_protocol_version),
-	GB_HANDLER(GB_CONTROL_TYPE_GET_MANIFEST_SIZE, gb_control_get_manifest_size),
-	GB_HANDLER(GB_CONTROL_TYPE_GET_MANIFEST, gb_control_get_manifest),
-	GB_HANDLER(GB_CONTROL_TYPE_CONNECTED, gb_control_connected),
-	GB_HANDLER(GB_CONTROL_TYPE_DISCONNECTED, gb_control_disconnected),
-	GB_HANDLER(GB_CONTROL_TYPE_INTERFACE_VERSION, gb_control_interface_version),
-	GB_HANDLER(GB_CONTROL_TYPE_DISCONNECTING, gb_control_disconnecting),
-	GB_HANDLER(GB_CONTROL_TYPE_BUNDLE_ACTIVATE, gb_control_bundle_activate),
-	GB_HANDLER(GB_CONTROL_TYPE_BUNDLE_SUSPEND, gb_control_bundle_suspend),
-	GB_HANDLER(GB_CONTROL_TYPE_BUNDLE_RESUME, gb_control_bundle_resume),
-	GB_HANDLER(GB_CONTROL_TYPE_BUNDLE_DEACTIVATE, gb_control_bundle_deactivate),
-	GB_HANDLER(GB_CONTROL_TYPE_INTF_SUSPEND_PREPARE, gb_control_intf_suspend_prepare),
-	GB_HANDLER(GB_CONTROL_TYPE_INTF_DEACTIVATE_PREPARE, gb_control_intf_deactivate_prepare),
+static uint8_t gb_control_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_CONTROL_TYPE_PROTOCOL_VERSION:
+		return gb_control_protocol_version(opr);
+	case GB_CONTROL_TYPE_GET_MANIFEST_SIZE:
+		return gb_control_get_manifest_size(opr);
+	case GB_CONTROL_TYPE_GET_MANIFEST:
+		return gb_control_get_manifest(opr);
+	case GB_CONTROL_TYPE_CONNECTED:
+		return gb_control_connected(opr);
+	case GB_CONTROL_TYPE_DISCONNECTED:
+		return gb_control_disconnected(opr);
+	case GB_CONTROL_TYPE_INTERFACE_VERSION:
+		return gb_control_interface_version(opr);
+	case GB_CONTROL_TYPE_DISCONNECTING:
+		return gb_control_disconnecting(opr);
+	case GB_CONTROL_TYPE_BUNDLE_ACTIVATE:
+		return gb_control_bundle_activate(opr);
+	case GB_CONTROL_TYPE_BUNDLE_SUSPEND:
+		return gb_control_bundle_suspend(opr);
+	case GB_CONTROL_TYPE_BUNDLE_RESUME:
+		return gb_control_bundle_resume(opr);
+	case GB_CONTROL_TYPE_BUNDLE_DEACTIVATE:
+		return gb_control_bundle_deactivate(opr);
+	case GB_CONTROL_TYPE_INTF_SUSPEND_PREPARE:
+		return gb_control_intf_suspend_prepare(opr);
+	case GB_CONTROL_TYPE_INTF_DEACTIVATE_PREPARE:
+		return gb_control_intf_deactivate_prepare(opr);
 	/* XXX SW-4136: see control-gb.h */
 	/*GB_HANDLER(GB_CONTROL_TYPE_INTF_POWER_STATE_SET, gb_control_intf_pwr_set),
 	GB_HANDLER(GB_CONTROL_TYPE_BUNDLE_POWER_STATE_SET, gb_control_bundle_pwr_set),*/
-	GB_HANDLER(GB_CONTROL_TYPE_TIMESYNC_ENABLE, gb_control_timesync_enable),
-	GB_HANDLER(GB_CONTROL_TYPE_TIMESYNC_DISABLE, gb_control_timesync_disable),
-	GB_HANDLER(GB_CONTROL_TYPE_TIMESYNC_AUTHORITATIVE, gb_control_timesync_authoritative),
-	GB_HANDLER(GB_CONTROL_TYPE_TIMESYNC_GET_LAST_EVENT, gb_control_timesync_get_last_event),
-};
+	case GB_CONTROL_TYPE_TIMESYNC_ENABLE:
+		return gb_control_timesync_enable(opr);
+	case GB_CONTROL_TYPE_TIMESYNC_DISABLE:
+		return gb_control_timesync_disable(opr);
+	case GB_CONTROL_TYPE_TIMESYNC_AUTHORITATIVE:
+		return gb_control_timesync_authoritative(opr);
+	case GB_CONTROL_TYPE_TIMESYNC_GET_LAST_EVENT:
+		return gb_control_timesync_get_last_event(opr);
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 struct gb_driver control_driver = {
-	.op_handlers = (struct gb_operation_handler *)gb_control_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_control_handlers),
+	.op_handler = gb_control_handler,
 };
 
 void gb_control_register(int cport, int bundle)

--- a/subsys/greybus/gpio.c
+++ b/subsys/greybus/gpio.c
@@ -519,21 +519,40 @@ static uint8_t gb_gpio_irq_type(struct gb_operation *operation)
 		gpio_pin_interrupt_configure(dev, request->which, mode | trigger));
 }
 
-static struct gb_operation_handler gb_gpio_handlers[] = {
-	GB_HANDLER(GB_GPIO_TYPE_PROTOCOL_VERSION, gb_gpio_protocol_version),
-	GB_HANDLER(GB_GPIO_TYPE_LINE_COUNT, gb_gpio_line_count),
-	GB_HANDLER(GB_GPIO_TYPE_ACTIVATE, gb_gpio_activate),
-	GB_HANDLER(GB_GPIO_TYPE_DEACTIVATE, gb_gpio_deactivate),
-	GB_HANDLER(GB_GPIO_TYPE_GET_DIRECTION, gb_gpio_get_direction),
-	GB_HANDLER(GB_GPIO_TYPE_DIRECTION_IN, gb_gpio_direction_in),
-	GB_HANDLER(GB_GPIO_TYPE_DIRECTION_OUT, gb_gpio_direction_out),
-	GB_HANDLER(GB_GPIO_TYPE_GET_VALUE, gb_gpio_get_value),
-	GB_HANDLER(GB_GPIO_TYPE_SET_VALUE, gb_gpio_set_value),
-	GB_HANDLER(GB_GPIO_TYPE_SET_DEBOUNCE, gb_gpio_set_debounce),
-	GB_HANDLER(GB_GPIO_TYPE_IRQ_TYPE, gb_gpio_irq_type),
-	GB_HANDLER(GB_GPIO_TYPE_IRQ_MASK, gb_gpio_irq_mask),
-	GB_HANDLER(GB_GPIO_TYPE_IRQ_UNMASK, gb_gpio_irq_unmask),
-};
+static uint8_t gb_gpio_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_GPIO_TYPE_PROTOCOL_VERSION:
+		return gb_gpio_protocol_version(opr);
+	case GB_GPIO_TYPE_LINE_COUNT:
+		return gb_gpio_line_count(opr);
+	case GB_GPIO_TYPE_ACTIVATE:
+		return gb_gpio_activate(opr);
+	case GB_GPIO_TYPE_DEACTIVATE:
+		return gb_gpio_deactivate(opr);
+	case GB_GPIO_TYPE_GET_DIRECTION:
+		return gb_gpio_get_direction(opr);
+	case GB_GPIO_TYPE_DIRECTION_IN:
+		return gb_gpio_direction_in(opr);
+	case GB_GPIO_TYPE_DIRECTION_OUT:
+		return gb_gpio_direction_out(opr);
+	case GB_GPIO_TYPE_GET_VALUE:
+		return gb_gpio_get_value(opr);
+	case GB_GPIO_TYPE_SET_VALUE:
+		return gb_gpio_set_value(opr);
+	case GB_GPIO_TYPE_SET_DEBOUNCE:
+		return gb_gpio_set_debounce(opr);
+	case GB_GPIO_TYPE_IRQ_TYPE:
+		return gb_gpio_irq_type(opr);
+	case GB_GPIO_TYPE_IRQ_MASK:
+		return gb_gpio_irq_mask(opr);
+	case GB_GPIO_TYPE_IRQ_UNMASK:
+		return gb_gpio_irq_unmask(opr);
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 static int gb_gpio_init(unsigned int cport, struct gb_bundle *bundle)
 {
@@ -555,8 +574,7 @@ static void gb_gpio_exit(unsigned int cport, struct gb_bundle *bundle)
 struct gb_driver gpio_driver = {
 	.init = gb_gpio_init,
 	.exit = gb_gpio_exit,
-	.op_handlers = (struct gb_operation_handler *)gb_gpio_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_gpio_handlers),
+	.op_handler = gb_gpio_handler,
 };
 
 void gb_gpio_register(int cport, int bundle)

--- a/subsys/greybus/greybus-core.c
+++ b/subsys/greybus/greybus-core.c
@@ -446,7 +446,6 @@ int greybus_rx_handler(unsigned int cport, void *data, size_t size)
 {
 	struct gb_operation *op;
 	struct gb_operation_hdr *hdr = data;
-	struct gb_operation_handler *op_handler;
 	size_t hdr_size;
 
 	gb_loopback_log_entry(cport);
@@ -482,13 +481,6 @@ int greybus_rx_handler(unsigned int cport, void *data, size_t size)
 
 		gb_tape->write(gb_tape_fd, &record_hdr, sizeof(record_hdr));
 		gb_tape->write(gb_tape_fd, data, size);
-	}
-
-	op_handler = find_operation_handler(hdr->type, cport);
-	if (op_handler && op_handler->fast_handler) {
-		LOG_DBG("%s", gb_handler_name(op_handler));
-		op_handler->fast_handler(cport, data);
-		return 0;
 	}
 
 	op = gb_rx_create_operation(cport, data, hdr_size);

--- a/subsys/greybus/hid.c
+++ b/subsys/greybus/hid.c
@@ -728,21 +728,33 @@ static void gb_hid_exit(unsigned int cport, struct gb_bundle *bundle)
 /**
  * @brief Greybus HID protocol operation handler
  */
-static struct gb_operation_handler gb_hid_handlers[] = {
-	GB_HANDLER(GB_HID_TYPE_PROTOCOL_VERSION, gb_hid_protocol_version),
-	GB_HANDLER(GB_HID_TYPE_GET_DESC, gb_hid_get_descriptor),
-	GB_HANDLER(GB_HID_TYPE_GET_REPORT_DESC, gb_hid_get_report_descriptor),
-	GB_HANDLER(GB_HID_TYPE_PWR_ON, gb_hid_power_on),
-	GB_HANDLER(GB_HID_TYPE_PWR_OFF, gb_hid_power_off),
-	GB_HANDLER(GB_HID_TYPE_GET_REPORT, gb_hid_get_report),
-	GB_HANDLER(GB_HID_TYPE_SET_REPORT, gb_hid_set_report),
-};
+static uint8_t gb_hid_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_HID_TYPE_PROTOCOL_VERSION:
+		return gb_hid_protocol_version(opr);
+	case GB_HID_TYPE_GET_DESC:
+		return gb_hid_get_descriptor(opr);
+	case GB_HID_TYPE_GET_REPORT_DESC:
+		return gb_hid_get_report_descriptor(opr);
+	case GB_HID_TYPE_PWR_ON:
+		return gb_hid_power_on(opr);
+	case GB_HID_TYPE_PWR_OFF:
+		return gb_hid_power_off(opr);
+	case GB_HID_TYPE_GET_REPORT:
+		return gb_hid_get_report(opr);
+	case GB_HID_TYPE_SET_REPORT:
+		return gb_hid_set_report(opr);
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 static struct gb_driver gb_hid_driver = {
 	.init = gb_hid_init,
 	.exit = gb_hid_exit,
-	.op_handlers = gb_hid_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_hid_handlers),
+	.op_handler = gb_hid_handler,
 };
 
 /**

--- a/subsys/greybus/lights.c
+++ b/subsys/greybus/lights.c
@@ -653,27 +653,45 @@ static void gb_lights_exit(unsigned int cport, struct gb_bundle *bundle)
 /**
  * @brief Greybus Lights Protocol operation handler
  */
-static struct gb_operation_handler gb_lights_handlers[] = {
-	GB_HANDLER(GB_LIGHTS_TYPE_PROTOCOL_VERSION, gb_lights_protocol_version),
-	GB_HANDLER(GB_LIGHTS_TYPE_GET_LIGHTS, gb_lights_get_lights),
-	GB_HANDLER(GB_LIGHTS_TYPE_GET_LIGHT_CONFIG, gb_lights_get_light_config),
-	GB_HANDLER(GB_LIGHTS_TYPE_GET_CHANNEL_CONFIG, gb_lights_get_channel_config),
-	GB_HANDLER(GB_LIGHTS_TYPE_GET_CHANNEL_FLASH_CONFIG, gb_lights_get_channel_flash_config),
-	GB_HANDLER(GB_LIGHTS_TYPE_SET_BRIGHTNESS, gb_lights_set_brightness),
-	GB_HANDLER(GB_LIGHTS_TYPE_SET_BLINK, gb_lights_set_blink),
-	GB_HANDLER(GB_LIGHTS_TYPE_SET_COLOR, gb_lights_set_color),
-	GB_HANDLER(GB_LIGHTS_TYPE_SET_FADE, gb_lights_set_fade),
-	GB_HANDLER(GB_LIGHTS_TYPE_SET_FLASH_INTENSITY, gb_lights_set_flash_intensity),
-	GB_HANDLER(GB_LIGHTS_TYPE_SET_FLASH_STROBE, gb_lights_set_flash_strobe),
-	GB_HANDLER(GB_LIGHTS_TYPE_SET_FLASH_TIMEOUT, gb_lights_set_flash_timeout),
-	GB_HANDLER(GB_LIGHTS_TYPE_GET_FLASH_FAULT, gb_lights_get_flash_fault),
-};
+static uint8_t gb_lights_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_LIGHTS_TYPE_PROTOCOL_VERSION:
+		return gb_lights_protocol_version(opr);
+	case GB_LIGHTS_TYPE_GET_LIGHTS:
+		return gb_lights_get_lights(opr);
+	case GB_LIGHTS_TYPE_GET_LIGHT_CONFIG:
+		return gb_lights_get_light_config(opr);
+	case GB_LIGHTS_TYPE_GET_CHANNEL_CONFIG:
+		return gb_lights_get_channel_config(opr);
+	case GB_LIGHTS_TYPE_GET_CHANNEL_FLASH_CONFIG:
+		return gb_lights_get_channel_flash_config(opr);
+	case GB_LIGHTS_TYPE_SET_BRIGHTNESS:
+		return gb_lights_set_brightness(opr);
+	case GB_LIGHTS_TYPE_SET_BLINK:
+		return gb_lights_set_blink(opr);
+	case GB_LIGHTS_TYPE_SET_COLOR:
+		return gb_lights_set_color(opr);
+	case GB_LIGHTS_TYPE_SET_FADE:
+		return gb_lights_set_fade(opr);
+	case GB_LIGHTS_TYPE_SET_FLASH_INTENSITY:
+		return gb_lights_set_flash_intensity(opr);
+	case GB_LIGHTS_TYPE_SET_FLASH_STROBE:
+		return gb_lights_set_flash_strobe(opr);
+	case GB_LIGHTS_TYPE_SET_FLASH_TIMEOUT:
+		return gb_lights_set_flash_timeout(opr);
+	case GB_LIGHTS_TYPE_GET_FLASH_FAULT:
+		return gb_lights_get_flash_fault(opr);
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 static struct gb_driver gb_lights_driver = {
 	.init = gb_lights_init,
 	.exit = gb_lights_exit,
-	.op_handlers = gb_lights_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_lights_handlers),
+	.op_handler = gb_lights_handler,
 };
 
 /**

--- a/subsys/greybus/loopback.c
+++ b/subsys/greybus/loopback.c
@@ -402,16 +402,25 @@ static uint8_t gb_loopback_ping_sink_req_cb(struct gb_operation *operation)
 	return GB_OP_SUCCESS;
 }
 
-static struct gb_operation_handler gb_loopback_handlers[] = {
-	GB_HANDLER(GB_LOOPBACK_TYPE_PROTOCOL_VERSION, gb_loopback_protocol_ver_cb),
-	GB_HANDLER(GB_LOOPBACK_TYPE_PING, gb_loopback_ping_sink_req_cb),
-	GB_HANDLER(GB_LOOPBACK_TYPE_TRANSFER, gb_loopback_transfer_req_cb),
-	GB_HANDLER(GB_LOOPBACK_TYPE_SINK, gb_loopback_ping_sink_req_cb),
-};
+static uint8_t gb_loopback_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_LOOPBACK_TYPE_PROTOCOL_VERSION:
+		return gb_loopback_protocol_ver_cb(opr);
+	case GB_LOOPBACK_TYPE_PING:
+		return gb_loopback_ping_sink_req_cb(opr);
+	case GB_LOOPBACK_TYPE_TRANSFER:
+		return gb_loopback_transfer_req_cb(opr);
+	case GB_LOOPBACK_TYPE_SINK:
+		return gb_loopback_ping_sink_req_cb(opr);
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 struct gb_driver loopback_driver = {
-	.op_handlers = (struct gb_operation_handler *)gb_loopback_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_loopback_handlers),
+	.op_handler = gb_loopback_handler,
 };
 
 #ifdef CONFIG_GREYBUS_FEATURE_HAVE_TIMESTAMPS

--- a/subsys/greybus/power_supply.c
+++ b/subsys/greybus/power_supply.c
@@ -408,20 +408,31 @@ static void gb_power_supply_exit(unsigned int cport, struct gb_bundle *bundle)
 /**
  * @brief Greybus power supply protocol operation handler
  */
-static struct gb_operation_handler gb_power_supply_handlers[] = {
-	GB_HANDLER(GB_POWER_SUPPLY_TYPE_VERSION, gb_power_supply_version),
-	GB_HANDLER(GB_POWER_SUPPLY_TYPE_GET_SUPPLIES, gb_power_supply_get_supplies),
-	GB_HANDLER(GB_POWER_SUPPLY_TYPE_GET_DESCRIPTION, gb_power_supply_get_description),
-	GB_HANDLER(GB_POWER_SUPPLY_TYPE_GET_PROP_DESCRIPTORS, gb_power_supply_get_prop_descriptors),
-	GB_HANDLER(GB_POWER_SUPPLY_TYPE_GET_PROPERTY, gb_power_supply_get_property),
-	GB_HANDLER(GB_POWER_SUPPLY_TYPE_SET_PROPERTY, gb_power_supply_set_property),
-};
+static uint8_t gb_power_supply_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_POWER_SUPPLY_TYPE_VERSION:
+		return gb_power_supply_version(opr);
+	case GB_POWER_SUPPLY_TYPE_GET_SUPPLIES:
+		return gb_power_supply_get_supplies(opr);
+	case GB_POWER_SUPPLY_TYPE_GET_DESCRIPTION:
+		return gb_power_supply_get_description(opr);
+	case GB_POWER_SUPPLY_TYPE_GET_PROP_DESCRIPTORS:
+		return gb_power_supply_get_prop_descriptors(opr);
+	case GB_POWER_SUPPLY_TYPE_GET_PROPERTY:
+		return gb_power_supply_get_property(opr);
+	case GB_POWER_SUPPLY_TYPE_SET_PROPERTY:
+		return gb_power_supply_set_property(opr);
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 static struct gb_driver gb_power_supply_driver = {
 	.init = gb_power_supply_init,
 	.exit = gb_power_supply_exit,
-	.op_handlers = gb_power_supply_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_power_supply_handlers),
+	.op_handler = gb_power_supply_handler,
 };
 
 /**

--- a/subsys/greybus/pwm-protocol.c
+++ b/subsys/greybus/pwm-protocol.c
@@ -496,16 +496,30 @@ void gb_pwm_exit(unsigned int cport, struct gb_bundle *bundle)
 /*
  * This structure is to define each PWM protocol operation of handling function.
  */
-static struct gb_operation_handler gb_pwm_handlers[] = {
-	GB_HANDLER(GB_PWM_PROTOCOL_VERSION, gb_pwm_protocol_version),
-	GB_HANDLER(GB_PWM_PROTOCOL_COUNT, gb_pwm_protocol_count),
-	GB_HANDLER(GB_PWM_PROTOCOL_ACTIVATE, gb_pwm_protocol_activate),
-	GB_HANDLER(GB_PWM_PROTOCOL_DEACTIVATE, gb_pwm_protocol_deactivate),
-	GB_HANDLER(GB_PWM_PROTOCOL_CONFIG, gb_pwm_protocol_config),
-	GB_HANDLER(GB_PWM_PROTOCOL_POLARITY, gb_pwm_protocol_polarity),
-	GB_HANDLER(GB_PWM_PROTOCOL_ENABLE, gb_pwm_protocol_enable),
-	GB_HANDLER(GB_PWM_PROTOCOL_DISABLE, gb_pwm_protocol_disable),
-};
+static uint8_t gb_pwm_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_PWM_PROTOCOL_VERSION:
+		return gb_pwm_protocol_version(opr);
+	case GB_PWM_PROTOCOL_COUNT:
+		return gb_pwm_protocol_count(opr);
+	case GB_PWM_PROTOCOL_ACTIVATE:
+		return gb_pwm_protocol_activate(opr);
+	case GB_PWM_PROTOCOL_DEACTIVATE:
+		return gb_pwm_protocol_deactivate(opr);
+	case GB_PWM_PROTOCOL_CONFIG:
+		return gb_pwm_protocol_config(opr);
+	case GB_PWM_PROTOCOL_POLARITY:
+		return gb_pwm_protocol_polarity(opr);
+	case GB_PWM_PROTOCOL_ENABLE:
+		return gb_pwm_protocol_enable(opr);
+	case GB_PWM_PROTOCOL_DISABLE:
+		return gb_pwm_protocol_disable(opr);
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 /*
  * This structure of information is for PWM protocol fimware to register to
@@ -514,8 +528,7 @@ static struct gb_operation_handler gb_pwm_handlers[] = {
 static struct gb_driver gb_pwm_driver = {
 	.init = gb_pwm_init,
 	.exit = gb_pwm_exit,
-	.op_handlers = gb_pwm_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_pwm_handlers),
+	.op_handler = gb_pwm_handler,
 };
 
 /**

--- a/subsys/greybus/sdio.c
+++ b/subsys/greybus/sdio.c
@@ -448,19 +448,29 @@ static void gb_sdio_exit(unsigned int cport, struct gb_bundle *bundle)
 /**
  * @brief Greybus SDIO protocol operation handler
  */
-static struct gb_operation_handler gb_sdio_handlers[] = {
-	GB_HANDLER(GB_SDIO_TYPE_PROTOCOL_VERSION, gb_sdio_protocol_version),
-	GB_HANDLER(GB_SDIO_TYPE_PROTOCOL_GET_CAPABILITIES, gb_sdio_protocol_get_capabilities),
-	GB_HANDLER(GB_SDIO_TYPE_PROTOCOL_SET_IOS, gb_sdio_protocol_set_ios),
-	GB_HANDLER(GB_SDIO_TYPE_PROTOCOL_COMMAND, gb_sdio_protocol_command),
-	GB_HANDLER(GB_SDIO_TYPE_PROTOCOL_TRANSFER, gb_sdio_protocol_transfer),
-};
+static uint8_t gb_sdio_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_SDIO_TYPE_PROTOCOL_VERSION:
+		return gb_sdio_protocol_version(opr);
+	case GB_SDIO_TYPE_PROTOCOL_GET_CAPABILITIES:
+		return gb_sdio_protocol_get_capabilities(opr);
+	case GB_SDIO_TYPE_PROTOCOL_SET_IOS:
+		return gb_sdio_protocol_set_ios(opr);
+	case GB_SDIO_TYPE_PROTOCOL_COMMAND:
+		return gb_sdio_protocol_command(opr);
+	case GB_SDIO_TYPE_PROTOCOL_TRANSFER:
+		return gb_sdio_protocol_transfer(opr);
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 static struct gb_driver sdio_driver = {
 	.init = gb_sdio_init,
 	.exit = gb_sdio_exit,
-	.op_handlers = gb_sdio_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_sdio_handlers),
+	.op_handler = gb_sdio_handler,
 };
 
 /**

--- a/subsys/greybus/spi.c
+++ b/subsys/greybus/spi.c
@@ -460,21 +460,27 @@ static void gb_spi_exit(unsigned int cport, struct gb_bundle *bundle)
 {
 }
 
-/**
- * @brief Greybus SPI protocol operation handler
- */
-static struct gb_operation_handler gb_spi_handlers[] = {
-	GB_HANDLER(GB_SPI_PROTOCOL_VERSION, gb_spi_protocol_version),
-	GB_HANDLER(GB_SPI_TYPE_MASTER_CONFIG, gb_spi_protocol_master_config),
-	GB_HANDLER(GB_SPI_TYPE_DEVICE_CONFIG, gb_spi_protocol_device_config),
-	GB_HANDLER(GB_SPI_PROTOCOL_TRANSFER, gb_spi_protocol_transfer),
-};
+static uint8_t gb_spi_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_SPI_PROTOCOL_VERSION:
+		return gb_spi_protocol_version(opr);
+	case GB_SPI_TYPE_MASTER_CONFIG:
+		return gb_spi_protocol_master_config(opr);
+	case GB_SPI_TYPE_DEVICE_CONFIG:
+		return gb_spi_protocol_device_config(opr);
+	case GB_SPI_PROTOCOL_TRANSFER:
+		return gb_spi_protocol_transfer(opr);
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 static struct gb_driver gb_spi_driver = {
 	.init = gb_spi_init,
 	.exit = gb_spi_exit,
-	.op_handlers = gb_spi_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_spi_handlers),
+	.op_handler = gb_spi_handler,
 };
 
 /**

--- a/subsys/greybus/uart.c
+++ b/subsys/greybus/uart.c
@@ -949,19 +949,29 @@ static void gb_uart_exit(unsigned int cport, struct gb_bundle *bundle)
 	free(info);
 }
 
-static struct gb_operation_handler gb_uart_handlers[] = {
-	GB_HANDLER(GB_UART_PROTOCOL_VERSION, gb_uart_protocol_version),
-	GB_HANDLER(GB_UART_PROTOCOL_SEND_DATA, gb_uart_send_data),
-	GB_HANDLER(GB_UART_PROTOCOL_SET_LINE_CODING, gb_uart_set_line_coding),
-	GB_HANDLER(GB_UART_PROTOCOL_SET_CONTROL_LINE_STATE, gb_uart_set_control_line_state),
-	GB_HANDLER(GB_UART_PROTOCOL_SEND_BREAK, gb_uart_send_break),
-};
+static uint8_t gb_uart_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_UART_PROTOCOL_VERSION:
+		return gb_uart_protocol_version(opr);
+	case GB_UART_PROTOCOL_SEND_DATA:
+		return gb_uart_send_data(opr);
+	case GB_UART_PROTOCOL_SET_LINE_CODING:
+		return gb_uart_set_line_coding(opr);
+	case GB_UART_PROTOCOL_SET_CONTROL_LINE_STATE:
+		return gb_uart_set_control_line_state(opr);
+	case GB_UART_PROTOCOL_SEND_BREAK:
+		return gb_uart_send_break(opr);
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 struct gb_driver uart_driver = {
 	.init = gb_uart_init,
 	.exit = gb_uart_exit,
-	.op_handlers = (struct gb_operation_handler *)gb_uart_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_uart_handlers),
+	.op_handler = gb_uart_handler,
 };
 
 /**

--- a/subsys/greybus/usb.c
+++ b/subsys/greybus/usb.c
@@ -131,19 +131,27 @@ static void gb_usb_exit(unsigned int cport, struct gb_bundle *bundle)
 	}
 }
 
-static struct gb_operation_handler gb_usb_handlers[] = {
-	GB_HANDLER(GB_USB_TYPE_PROTOCOL_VERSION, gb_usb_protocol_version),
-	GB_HANDLER(GB_USB_TYPE_HCD_STOP, gb_usb_hcd_stop),
-	GB_HANDLER(GB_USB_TYPE_HCD_START, gb_usb_hcd_start),
-	GB_HANDLER(GB_USB_TYPE_HUB_CONTROL, gb_usb_hub_control),
-};
+static uint8_t gb_usb_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_USB_TYPE_PROTOCOL_VERSION:
+		return gb_usb_protocol_version(opr);
+	case GB_USB_TYPE_HCD_STOP:
+		return gb_usb_hcd_stop(opr);
+	case GB_USB_TYPE_HCD_START:
+		return gb_usb_hcd_start(opr);
+	case GB_USB_TYPE_HUB_CONTROL:
+		return gb_usb_hub_control(opr);
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 struct gb_driver usb_driver = {
-	.op_handlers = (struct gb_operation_handler *)gb_usb_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_usb_handlers),
-
 	.init = gb_usb_init,
 	.exit = gb_usb_exit,
+	.op_handler = gb_usb_handler,
 };
 
 void gb_usb_register(int cport, int bundle)

--- a/subsys/greybus/vibrator.c
+++ b/subsys/greybus/vibrator.c
@@ -92,15 +92,23 @@ static uint8_t gb_vibrator_vibrator_off(struct gb_operation *operation)
 	return GB_OP_SUCCESS;
 }
 
-static struct gb_operation_handler gb_vibrator_handlers[] = {
-	GB_HANDLER(GB_VIBRATOR_TYPE_PROTOCOL_VERSION, gb_vibrator_protocol_version),
-	GB_HANDLER(GB_VIBRATOR_TYPE_VIBRATOR_ON, gb_vibrator_vibrator_on),
-	GB_HANDLER(GB_VIBRATOR_TYPE_VIBRATOR_OFF, gb_vibrator_vibrator_off),
-};
+static uint8_t gb_vibrator_handler(uint8_t type, struct gb_operation *opr)
+{
+	switch (type) {
+	case GB_VIBRATOR_TYPE_PROTOCOL_VERSION:
+		return gb_vibrator_protocol_version(opr);
+	case GB_VIBRATOR_TYPE_VIBRATOR_ON:
+		return gb_vibrator_vibrator_on(opr);
+	case GB_VIBRATOR_TYPE_VIBRATOR_OFF:
+		return gb_vibrator_vibrator_off(opr);
+	default:
+		LOG_ERR("Invalid type");
+		return GB_OP_INVALID;
+	}
+}
 
 static struct gb_driver gb_vibrator_driver = {
-	.op_handlers = gb_vibrator_handlers,
-	.op_handlers_count = ARRAY_SIZE(gb_vibrator_handlers),
+	.op_handler = gb_vibrator_handler,
 };
 
 void gb_vibrator_register(int cport, int bundle)


### PR DESCRIPTION
- Reduces code size.
- Most protocols seem to have a small number of functions. Not really
  useful to have jumptable there.
