### PR TITLE
Potential fix for code scanning alert no. 3: Unsigned difference expression compared to zero

### DIFF
--- a/tests/subsys/greybus/gpio/src/gpio.c
+++ b/tests/subsys/greybus/gpio/src/gpio.c
@@ -244,7 +244,7 @@ static void tx_rx(const struct gb_operation_hdr *req, struct gb_operation_hdr *r
 			 */
 			continue;
 		}
-		if (rsp_size - hdr_size > 0) {
+		if (rsp_size > hdr_size) {
 			r = recv(fd, (uint8_t *)rsp + hdr_size, rsp_size - hdr_size, 0);
 			zassert_not_equal(r, -1, "recv: %s", errno);
 			zassert_equal(r, rsp_size - hdr_size, "expected: %u actual: %d",


### PR DESCRIPTION
Potential fix for [https://github.com/Ayush1325/greybus-for-zephyr/security/code-scanning/3](https://github.com/Ayush1325/greybus-for-zephyr/security/code-scanning/3)

To prevent unsigned underflow in the conditional `if (rsp_size - hdr_size > 0)`, we should compare the variables directly, rather than subtracting and comparing to zero. Since both `rsp_size` and `hdr_size` are either `size_t` or very likely unsigned, use `if (rsp_size > hdr_size)` instead.

Specifically:
- Replace `if (rsp_size - hdr_size > 0)` (line 247) with `if (rsp_size > hdr_size)`.
- Ensure that all uses of `rsp_size - hdr_size` within the block are safe, which they are if we guarantee `rsp_size > hdr_size` via the condition.

No additional imports are needed. No function definitions or type changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
