### PR TITLE
Remove bundles from importent code paths

### DIFF
--- a/include/greybus-utils/manifest.h
+++ b/include/greybus-utils/manifest.h
@@ -36,11 +36,11 @@
 #define _GREYBUS_BASE_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_greybus)
 
 #define _GREYBUS_CPORT_COUNTER(_node_id)                                                           \
-	COND_CODE_1(DT_NODE_HAS_COMPAT(_node_id, zephyr_greybus_bundle),                            \
-		   (DT_CHILD_NUM_STATUS_OKAY(_node_id)), (0))
+	COND_CODE_1(DT_NODE_HAS_COMPAT(_node_id, zephyr_greybus_bundle),                           \
+		    (DT_CHILD_NUM_STATUS_OKAY(_node_id)), (0))
 
 #define GREYBUS_CPORT_COUNT                                                                        \
-	DT_FOREACH_CHILD_STATUS_OKAY_SEP(_GREYBUS_BASE_NODE, _GREYBUS_CPORT_COUNTER, (+))
+	(DT_FOREACH_CHILD_STATUS_OKAY_SEP(_GREYBUS_BASE_NODE, _GREYBUS_CPORT_COUNTER, (+)))
 
 struct gb_cport {
 	sys_dnode_t node;

--- a/include/greybus/greybus.h
+++ b/include/greybus/greybus.h
@@ -73,7 +73,6 @@ struct gb_transport_backend {
 struct gb_bundle {
 	int id;                   /* bundle ID */
 	unsigned int cport_start; /* start cport */
-	struct device **dev;      /* primary bundle device */
 	void *priv;               /* private bundle data */
 };
 

--- a/include/greybus/greybus.h
+++ b/include/greybus/greybus.h
@@ -89,7 +89,7 @@ struct gb_driver {
 	 * in bundle->priv. The same bundle object will be passed to the driver in
 	 * all subsequent greybus handler callbacks calls.
 	 */
-	int (*init)(unsigned int cport, struct gb_bundle *bundle);
+	int (*init)(unsigned int cport);
 	/*
 	 * This function is called upon driver deregistration. All private data
 	 * stored in bundle should be freed and struct device should be closed.

--- a/include/greybus/greybus.h
+++ b/include/greybus/greybus.h
@@ -70,12 +70,6 @@ struct gb_transport_backend {
 	int (*send)(uint16_t cport, const struct gb_message *msg);
 };
 
-struct gb_bundle {
-	int id;                   /* bundle ID */
-	unsigned int cport_start; /* start cport */
-	void *priv;               /* private bundle data */
-};
-
 struct gb_driver;
 
 typedef void (*gb_operation_handler_t)(struct gb_driver *drv, struct gb_message *msg, uint16_t cport);

--- a/include/greybus/greybus.h
+++ b/include/greybus/greybus.h
@@ -94,7 +94,7 @@ struct gb_driver {
 	 * This function is called upon driver deregistration. All private data
 	 * stored in bundle should be freed and struct device should be closed.
 	 */
-	void (*exit)(unsigned int cport, struct gb_bundle *bundle);
+	void (*exit)(unsigned int cport);
 	void (*connected)(unsigned int cport);
 	void (*disconnected)(unsigned int cport);
 

--- a/include/greybus/greybus.h
+++ b/include/greybus/greybus.h
@@ -101,8 +101,6 @@ struct gb_driver {
 	gb_operation_handler_t op_handler;
 
 	const char *name;
-
-	struct gb_bundle *bundle;
 };
 
 struct gb_operation_hdr {

--- a/subsys/greybus/gpio.c
+++ b/subsys/greybus/gpio.c
@@ -402,15 +402,8 @@ static int gb_gpio_init(unsigned int cport, struct gb_bundle *bundle)
 	return 0;
 }
 
-static void gb_gpio_exit(unsigned int cport, struct gb_bundle *bundle)
-{
-	ARG_UNUSED(cport);
-	ARG_UNUSED(bundle);
-}
-
 struct gb_driver gpio_driver = {
 	.init = gb_gpio_init,
-	.exit = gb_gpio_exit,
 	.op_handler = gb_gpio_handler,
 };
 

--- a/subsys/greybus/gpio.c
+++ b/subsys/greybus/gpio.c
@@ -391,19 +391,7 @@ static void gb_gpio_handler(struct gb_driver *drv, struct gb_message *msg, uint1
 	}
 }
 
-static int gb_gpio_init(unsigned int cport, struct gb_bundle *bundle)
-{
-	unsigned int cport_idx = cport - bundle->cport_start;
-
-	bundle->dev[cport_idx] = (struct device *)gb_cport_to_device(cport);
-	if (!bundle->dev[cport_idx]) {
-		return -EIO;
-	}
-	return 0;
-}
-
 struct gb_driver gpio_driver = {
-	.init = gb_gpio_init,
 	.op_handler = gb_gpio_handler,
 };
 

--- a/subsys/greybus/greybus-core.c
+++ b/subsys/greybus/greybus-core.c
@@ -274,7 +274,7 @@ int _gb_register_driver(unsigned int cport, int bundle_id, struct gb_driver *dri
 	}
 
 	if (driver->init) {
-		retval = driver->init(cport, bundle);
+		retval = driver->init(cport);
 		if (retval) {
 			LOG_ERR("Can not init %s", gb_driver_name(driver));
 			return retval;

--- a/subsys/greybus/greybus-core.c
+++ b/subsys/greybus/greybus-core.c
@@ -74,7 +74,6 @@ LOG_MODULE_REGISTER(greybus, CONFIG_GREYBUS_LOG_LEVEL);
 
 static unsigned int cport_count;
 static struct gb_cport_driver *g_cport;
-static struct gb_bundle **g_bundle;
 static struct gb_transport_backend *transport_backend;
 
 K_MSGQ_DEFINE(gb_rx_msgq, sizeof(struct gb_msg_with_cport), 10, 1);
@@ -216,7 +215,6 @@ int gb_unregister_driver(unsigned int cport)
 
 int _gb_register_driver(unsigned int cport, int bundle_id, struct gb_driver *driver)
 {
-	struct gb_bundle *bundle;
 	char thread_name[CONFIG_THREAD_MAX_NAME_LEN];
 	int retval;
 
@@ -246,29 +244,6 @@ int _gb_register_driver(unsigned int cport, int bundle_id, struct gb_driver *dri
 	if (bundle_id >= 0 && bundle_id > manifest_get_max_bundle_id()) {
 		LOG_ERR("invalid bundle_id: %d", bundle_id);
 		return -EINVAL;
-	}
-
-	if (bundle_id >= 0 && !g_bundle[bundle_id]) {
-		/*
-		 * TODO We should probably add a mechanism to destroy the bundle
-		 * objects allocated here, but since for now we don't really use any
-		 * actual shutdown procedure we'll leave it as a TODO.
-		 *
-		 * Eventually we'd need some reference counting mechanism, because we
-		 * call _gb_register_driver() once per used cport. We would need to
-		 * know when when there are no more cports referencing given bundle
-		 * and it's safe to free it.
-		 */
-		bundle = calloc(1, sizeof(struct gb_bundle));
-		if (!bundle) {
-			return -ENOMEM;
-		}
-
-		bundle->id = bundle_id;
-		bundle->cport_start = manifest_get_start_cport_bundle(bundle_id);
-		g_bundle[bundle_id] = bundle;
-	} else {
-		bundle = g_bundle[bundle_id];
 	}
 
 	if (driver->init) {
@@ -326,21 +301,13 @@ int gb_stop_listening(unsigned int cport)
 
 int gb_init(struct gb_transport_backend *transport)
 {
-	size_t num_bundles = manifest_get_max_bundle_id() + 1;
-
 	if (!transport) {
 		return -EINVAL;
-	}
-
-	g_bundle = calloc(1, sizeof(struct gb_bundle *) * num_bundles);
-	if (!g_bundle) {
-		return -ENOMEM;
 	}
 
 	cport_count = unipro_cport_count();
 	g_cport = calloc(1, sizeof(struct gb_cport_driver) * cport_count);
 	if (!g_cport) {
-		free(g_bundle);
 		return -ENOMEM;
 	}
 

--- a/subsys/greybus/greybus-core.c
+++ b/subsys/greybus/greybus-core.c
@@ -207,7 +207,7 @@ int gb_unregister_driver(unsigned int cport)
 	g_cport[cport].exit_worker = true;
 
 	if (g_cport[cport].driver->exit) {
-		g_cport[cport].driver->exit(cport, g_cport[cport].driver->bundle);
+		g_cport[cport].driver->exit(cport);
 	}
 	g_cport[cport].driver = NULL;
 

--- a/subsys/greybus/greybus-core.c
+++ b/subsys/greybus/greybus-core.c
@@ -219,7 +219,6 @@ int _gb_register_driver(unsigned int cport, int bundle_id, struct gb_driver *dri
 	struct gb_bundle *bundle;
 	char thread_name[CONFIG_THREAD_MAX_NAME_LEN];
 	int retval;
-	size_t num_cports = manifest_get_num_cports_bundle(bundle_id);
 
 	LOG_DBG("Registering Greybus driver on CP%u", cport);
 
@@ -267,7 +266,6 @@ int _gb_register_driver(unsigned int cport, int bundle_id, struct gb_driver *dri
 
 		bundle->id = bundle_id;
 		bundle->cport_start = manifest_get_start_cport_bundle(bundle_id);
-		bundle->dev = calloc(1, num_cports * sizeof(struct device *));
 		g_bundle[bundle_id] = bundle;
 	} else {
 		bundle = g_bundle[bundle_id];

--- a/subsys/greybus/greybus-core.c
+++ b/subsys/greybus/greybus-core.c
@@ -273,8 +273,6 @@ int _gb_register_driver(unsigned int cport, int bundle_id, struct gb_driver *dri
 		bundle = g_bundle[bundle_id];
 	}
 
-	driver->bundle = bundle;
-
 	if (driver->init) {
 		retval = driver->init(cport, bundle);
 		if (retval) {

--- a/subsys/greybus/i2c.c
+++ b/subsys/greybus/i2c.c
@@ -156,19 +156,6 @@ free_requests:
 	return gb_transport_message_empty_response_send(req, ret, cport);
 }
 
-static int gb_i2c_init(unsigned int cport, struct gb_bundle *bundle)
-{
-	unsigned int cport_idx = cport - bundle->cport_start;
-	__ASSERT_NO_MSG(bundle != NULL);
-
-	bundle->dev[cport_idx] = (struct device *)gb_cport_to_device(cport);
-	if (!bundle->dev[cport_idx]) {
-		return -EIO;
-	}
-
-	return 0;
-}
-
 static void gb_i2c_handler(struct gb_driver *drv, struct gb_message *msg, uint16_t cport)
 {
 	switch (gb_message_type(msg)) {
@@ -185,7 +172,6 @@ static void gb_i2c_handler(struct gb_driver *drv, struct gb_message *msg, uint16
 }
 
 static struct gb_driver gb_i2c_driver = {
-	.init = gb_i2c_init,
 	.op_handler = gb_i2c_handler,
 };
 

--- a/subsys/greybus/i2c.c
+++ b/subsys/greybus/i2c.c
@@ -169,12 +169,6 @@ static int gb_i2c_init(unsigned int cport, struct gb_bundle *bundle)
 	return 0;
 }
 
-static void gb_i2c_exit(unsigned int cport, struct gb_bundle *bundle)
-{
-	ARG_UNUSED(cport);
-	ARG_UNUSED(bundle);
-}
-
 static void gb_i2c_handler(struct gb_driver *drv, struct gb_message *msg, uint16_t cport)
 {
 	switch (gb_message_type(msg)) {
@@ -192,7 +186,6 @@ static void gb_i2c_handler(struct gb_driver *drv, struct gb_message *msg, uint16
 
 static struct gb_driver gb_i2c_driver = {
 	.init = gb_i2c_init,
-	.exit = gb_i2c_exit,
 	.op_handler = gb_i2c_handler,
 };
 

--- a/subsys/greybus/platform/manifest.c
+++ b/subsys/greybus/platform/manifest.c
@@ -7,6 +7,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 #include <greybus-utils/manifest.h>
+#include "../greybus-manifest.h"
 
 struct greybus_manifest_cport {
 	uint8_t bundle;
@@ -69,10 +70,10 @@ static struct greybus_manifest_cport cports[GREYBUS_CPORT_COUNT] = {
 	(sizeof(struct greybus_manifest_header) + GREYBUS_MANIFEST_INTERFACE_SIZE +                \
 	 GREYBUS_MANIFEST_STRING_SIZE(CONFIG_GREYBUS_VENDOR_STRING) +                              \
 	 GREYBUS_MANIFEST_STRING_SIZE(CONFIG_GREYBUS_PRODUCT_STRING) +                             \
-	 _GREYBUS_MANIFEST_CPORTS_SIZE(GREYBUS_CPORT_COUNT) +                                       \
+	 _GREYBUS_MANIFEST_CPORTS_SIZE(GREYBUS_CPORT_COUNT) +                                      \
 	 _GREYBUS_MANIFEST_BUNDLES_SIZE(ARRAY_SIZE(bundles)))
 
-#include "../greybus-manifest.h"
+static unsigned char greybus_manifest_builtin[GREYBUS_MANIFEST_SIZE];
 
 size_t manifest_size(void)
 {
@@ -179,8 +180,6 @@ static int manifest_create(uint8_t buf[], size_t len)
 
 uint8_t *manifest_get(void)
 {
-	static unsigned char greybus_manifest_builtin[GREYBUS_MANIFEST_SIZE];
-
 	manifest_create(greybus_manifest_builtin, GREYBUS_MANIFEST_SIZE);
 
 	if (IS_ENABLED(CONFIG_GREYBUS_MANIFEST_BUILTIN)) {

--- a/subsys/greybus/spi.c
+++ b/subsys/greybus/spi.c
@@ -432,16 +432,6 @@ static int gb_spi_init(unsigned int cport, struct gb_bundle *bundle)
 	return 0;
 }
 
-/**
- * @brief Greybus SPI protocol deinitialize function
- *
- * @param cport CPort number
- * @param bundle Greybus bundle handle
- */
-static void gb_spi_exit(unsigned int cport, struct gb_bundle *bundle)
-{
-}
-
 static void gb_spi_handler(struct gb_driver *drv, struct gb_message *msg, uint16_t cport)
 {
 	const struct device *dev = gb_cport_to_device(cport);
@@ -463,7 +453,6 @@ static void gb_spi_handler(struct gb_driver *drv, struct gb_message *msg, uint16
 
 static struct gb_driver gb_spi_driver = {
 	.init = gb_spi_init,
-	.exit = gb_spi_exit,
 	.op_handler = gb_spi_handler,
 };
 

--- a/subsys/greybus/spi.c
+++ b/subsys/greybus/spi.c
@@ -414,24 +414,6 @@ out:
 	gb_transport_message_empty_response_send(req, errcode, cport);
 }
 
-/**
- * @brief Greybus SPI protocol initialize function
- *
- * @param cport CPort number
- * @param bundle Greybus bundle handle
- * @return 0 on success, negative errno on error
- */
-static int gb_spi_init(unsigned int cport, struct gb_bundle *bundle)
-{
-	unsigned int cport_idx = cport - bundle->cport_start;
-
-	bundle->dev[cport_idx] = (struct device *)gb_cport_to_device(cport);
-	if (!bundle->dev[cport_idx]) {
-		return -EIO;
-	}
-	return 0;
-}
-
 static void gb_spi_handler(struct gb_driver *drv, struct gb_message *msg, uint16_t cport)
 {
 	const struct device *dev = gb_cport_to_device(cport);
@@ -452,7 +434,6 @@ static void gb_spi_handler(struct gb_driver *drv, struct gb_message *msg, uint16
 }
 
 static struct gb_driver gb_spi_driver = {
-	.init = gb_spi_init,
 	.op_handler = gb_spi_handler,
 };
 


### PR DESCRIPTION
Bundles should be an internal manifest detail, and not hold important data.