### PR TITLE
subsys: greybus: Add common heap

### DIFF
--- a/samples/subsys/greybus/net/prj.conf
+++ b/samples/subsys/greybus/net/prj.conf
@@ -1,5 +1,3 @@
-CONFIG_HEAP_MEM_POOL_SIZE=2048
-
 # Greybus options and dependencies
 CONFIG_GREYBUS=y
 CONFIG_GREYBUS_CONTROL=y

--- a/subsys/greybus/CMakeLists.txt
+++ b/subsys/greybus/CMakeLists.txt
@@ -9,6 +9,7 @@ zephyr_library_sources(
   greybus-core.c
   greybus_messages.c
   greybus_transport.c
+  greybus_heap.c
   greybus_cport.c
   platform/manifest.c
   platform/service.c

--- a/subsys/greybus/Kconfig
+++ b/subsys/greybus/Kconfig
@@ -27,11 +27,11 @@ config GREYBUS_VERSION_MINOR
 	int
 	default 1
 
-config GREYBUS_MESSAGES_HEAP_MEM_POOL_SIZE
-	int "Heap for Greybus messages"
+config GREYBUS_HEAP_MEM_POOL_SIZE
+	int "Heap for Greybus subsystem"
 	default 2048
 	help
-	  Heap memory pre-allocated for greybus messages
+	  Heap memory pre-allocated for greybus subsystem
 
 choice
 	prompt "Greybus Manifest Source"

--- a/subsys/greybus/greybus_heap.c
+++ b/subsys/greybus/greybus_heap.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025 Ayush Singh BeagleBoard.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Provides common heap for greybus subsystem.
+ */
+
+#include "greybus_heap.h"
+#include <zephyr/kernel.h>
+
+K_HEAP_DEFINE(greybus_heap, CONFIG_GREYBUS_HEAP_MEM_POOL_SIZE);
+
+void *gb_alloc(size_t len)
+{
+	return k_heap_alloc(&greybus_heap, len, K_FOREVER);
+}
+
+void gb_free(void *ptr)
+{
+	k_heap_free(&greybus_heap, ptr);
+}

--- a/subsys/greybus/greybus_heap.h
+++ b/subsys/greybus/greybus_heap.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2025 Ayush Singh BeagleBoard.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Provides common heap for greybus subsystem.
+ */
+
+#ifndef _GREYBUS_HEAP_H_
+#define _GREYBUS_HEAP_H_
+
+#include <stddef.h>
+
+void *gb_alloc(size_t len);
+
+void gb_free(void *ptr);
+
+#endif // _GREYBUS_HEAP_H_

--- a/subsys/greybus/greybus_messages.c
+++ b/subsys/greybus/greybus_messages.c
@@ -6,11 +6,11 @@
 #include "greybus_messages.h"
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
+#include "greybus_heap.h"
 
 #define OPERATION_ID_START 1
 
 LOG_MODULE_REGISTER(greybus_messages, CONFIG_GREYBUS_LOG_LEVEL);
-K_HEAP_DEFINE(greybus_messages_heap, CONFIG_GREYBUS_MESSAGES_HEAP_MEM_POOL_SIZE);
 
 static atomic_t operation_id_counter = ATOMIC_INIT(OPERATION_ID_START);
 
@@ -29,8 +29,7 @@ struct gb_message *gb_message_alloc(size_t payload_len, uint8_t message_type, ui
 {
 	struct gb_message *msg;
 
-	msg = k_heap_alloc(&greybus_messages_heap, sizeof(struct gb_message) + payload_len,
-			   K_NO_WAIT);
+	msg = gb_alloc(sizeof(struct gb_message) + payload_len);
 	if (msg == NULL) {
 		LOG_WRN("Failed to allocate Greybus request message");
 		return NULL;
@@ -46,7 +45,7 @@ struct gb_message *gb_message_alloc(size_t payload_len, uint8_t message_type, ui
 
 void gb_message_dealloc(struct gb_message *msg)
 {
-	k_heap_free(&greybus_messages_heap, msg);
+	gb_free(msg);
 }
 
 struct gb_message *gb_message_request_alloc(const void *payload, size_t payload_len,

--- a/subsys/greybus/i2c.c
+++ b/subsys/greybus/i2c.c
@@ -36,6 +36,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 
+#include "greybus_heap.h"
 #include "greybus_messages.h"
 #include "greybus_transport.h"
 #include "i2c-gb.h"
@@ -110,7 +111,7 @@ static void gb_i2c_protocol_transfer(uint16_t cport, struct gb_message *req,
 	}
 	resp_data = (struct gb_i2c_transfer_rsp *)resp->payload;
 
-	requests = malloc(sizeof(*requests) * op_count);
+	requests = gb_alloc(sizeof(*requests) * op_count);
 	if (!requests) {
 		ret = GB_OP_NO_MEMORY;
 		goto free_msg;
@@ -151,7 +152,7 @@ static void gb_i2c_protocol_transfer(uint16_t cport, struct gb_message *req,
 free_msg:
 	gb_message_dealloc(resp);
 free_requests:
-	free(requests);
+	gb_free(requests);
 
 	return gb_transport_message_empty_response_send(req, ret, cport);
 }

--- a/subsys/greybus/spi.c
+++ b/subsys/greybus/spi.c
@@ -26,6 +26,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "greybus_heap.h"
 #include "greybus_messages.h"
 #include "greybus_transport.h"
 #include <zephyr/device.h>
@@ -308,7 +309,7 @@ static void gb_spi_protocol_transfer(uint16_t cport, struct gb_message *req,
 		}
 	}
 
-	tx_buf = malloc(op_count * 2 * sizeof(*tx_buf));
+	tx_buf = gb_alloc(op_count * 2 * sizeof(*tx_buf));
 	rx_buf = &tx_buf[op_count];
 	if (tx_buf == NULL) {
 		free(tx_buf);
@@ -408,7 +409,7 @@ freemsg:
 	gb_message_dealloc(resp);
 
 freebufs:
-	free(tx_buf);
+	gb_free(tx_buf);
 
 out:
 	gb_transport_message_empty_response_send(req, errcode, cport);


### PR DESCRIPTION
- Using a common heap for greybus subsystem allocations.
- Should only be used for non-fixed sized items. Better to use slabs for fixed-sized item allocation.
- Fixes #12