### PR TITLE
Add back node to ap events

### DIFF
--- a/include/greybus/greybus.h
+++ b/include/greybus/greybus.h
@@ -84,7 +84,7 @@ struct gb_driver {
 	 * in bundle->priv. The same bundle object will be passed to the driver in
 	 * all subsequent greybus handler callbacks calls.
 	 */
-	int (*init)(const void *priv);
+	int (*init)(const void *priv, uint16_t cport);
 	/*
 	 * This function is called upon driver deregistration. All private data
 	 * stored in bundle should be freed and struct device should be closed.

--- a/subsys/greybus/greybus-core.c
+++ b/subsys/greybus/greybus-core.c
@@ -193,8 +193,15 @@ int gb_stop_listening(uint16_t cport)
 
 int gb_init(struct gb_transport_backend *transport)
 {
+	int ret;
+
 	if (!transport) {
 		return -EINVAL;
+	}
+
+	ret = gb_cports_init();
+	if (ret < 0) {
+		return ret;
 	}
 
 	gb_rx_threadid = k_thread_create(
@@ -215,6 +222,8 @@ void gb_deinit(void)
 	}
 
 	k_thread_abort(gb_rx_threadid);
+
+	gb_cports_deinit();
 
 	if (transport->exit) {
 		transport->exit();

--- a/subsys/greybus/greybus_cport.c
+++ b/subsys/greybus/greybus_cport.c
@@ -81,3 +81,39 @@ struct gb_cport *gb_cport_get(uint16_t cport)
 {
 	return (cport >= GREYBUS_CPORT_COUNT) ? NULL : &cports[cport];
 }
+
+int gb_cports_init()
+{
+	size_t i;
+	int ret;
+	const struct gb_cport *cport;
+
+	for (i = 0; i < ARRAY_SIZE(cports); ++i) {
+		cport = &cports[i];
+
+		if (cport->driver->init) {
+			ret = cport->driver->init(cport->priv, i);
+			if (ret < 0) {
+				LOG_ERR("Failed to initialize cport %u", i);
+				return ret;
+			}
+		}
+	}
+
+	return 0;
+}
+
+void gb_cports_deinit()
+{
+
+	size_t i;
+	const struct gb_cport *cport;
+
+	for (i = 0; i < ARRAY_SIZE(cports); ++i) {
+		cport = &cports[i];
+
+		if (cport->driver->exit) {
+			cport->driver->exit(cport->priv);
+		}
+	}
+}

--- a/subsys/greybus/greybus_cport.h
+++ b/subsys/greybus/greybus_cport.h
@@ -18,4 +18,11 @@ struct gb_cport {
 
 struct gb_cport *gb_cport_get(uint16_t cport);
 
+/**
+ * Initialize all cports.
+ */
+int gb_cports_init();
+
+void gb_cports_deinit();
+
 #endif // _GREYBUS_CPORT_H_

--- a/subsys/greybus/greybus_gpio.h
+++ b/subsys/greybus/greybus_gpio.h
@@ -12,6 +12,7 @@
 struct gb_gpio_driver_data {
 	struct gpio_callback cb;
 	const struct device *const dev;
+	uint16_t cport;
 };
 
 #endif // _GREYBUS_GPIO_H_


### PR DESCRIPTION
- Add ability to register callbacks for some bridged devices like gpio.
- This was removed when removing platform devices.