### PR TITLE
subsys: greybus: Kconfig: Refactor

### DIFF
--- a/subsys/greybus/Kconfig
+++ b/subsys/greybus/Kconfig
@@ -240,34 +240,6 @@ config GREYBUS_SERVICE_INIT_PRIORITY
 	help
 	  Greybus service init priority to ensure device initialization order.
 
-config GREYBUS_STRING_INIT_PRIORITY
-	int "default Greybus String Init Priority"
-	default 86
-	range 0 99
-	help
-	  Greybus string init priority to ensure device initialization order.
-
-config GREYBUS_INTERFACE_INIT_PRIORITY
-	int "default Greybus Interface Init Priority"
-	default 87
-	range 0 99
-	help
-	  Greybus interface init priority to ensure device initialization order.
-
-config GREYBUS_BUNDLE_INIT_PRIORITY
-	int "default Greybus Bundle Init Priority"
-	default 88
-	range 0 99
-	help
-	  Greybus bundle init priority to ensure device initialization order.
-
-config GREYBUS_CPORT_INIT_PRIORITY
-	int "default Greybus Cport Init Priority"
-	default 89
-	range 0 99
-	help
-	  Greybus cport init priority to ensure device initialization order.
-
 module = GREYBUS
 module-str = Greybus
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/greybus/platform/service.c
+++ b/subsys/greybus/platform/service.c
@@ -49,4 +49,4 @@ clear_mnfb:
 	return r;
 }
 
-SYS_INIT(greybus_service_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
+SYS_INIT(greybus_service_init, APPLICATION, CONFIG_GREYBUS_SERVICE_INIT_PRIORITY);


### PR DESCRIPTION
- Remove unused options.
- Use init priority from kconfig instead of the application init priority.