### PR TITLE
subsys: greybus: Fix find firmware request

### DIFF
--- a/include/greybus/greybus_protocols.h
+++ b/include/greybus/greybus_protocols.h
@@ -210,11 +210,13 @@ struct gb_apb_request_cport_flags {
 #define GB_FW_DOWNLOAD_TYPE_FETCH_FIRMWARE   0x02
 #define GB_FW_DOWNLOAD_TYPE_RELEASE_FIRMWARE 0x03
 
-#define GB_FIRMWARE_TAG_MAX_SIZE 10
+#define GB_FIRMWARE_TAG_MAX_SIZE    10
+#define GB_FIRMWARE_FORMAT_MAX_SIZE 10
 
 /* firmware download find firmware request/response */
 struct gb_fw_download_find_firmware_request {
 	__u8 firmware_tag[GB_FIRMWARE_TAG_MAX_SIZE];
+	__u8 format[GB_FIRMWARE_FORMAT_MAX_SIZE];
 } __packed;
 
 struct gb_fw_download_find_firmware_response {

--- a/subsys/greybus/fw_download.c
+++ b/subsys/greybus/fw_download.c
@@ -178,6 +178,7 @@ struct gb_driver gb_fw_download_driver = {
 
 void gb_fw_download_find_firmware(uint8_t req_id, const char *firmware_tag)
 {
+	const char format[] = "bin";
 	struct gb_message *req =
 		gb_message_request_alloc(sizeof(struct gb_fw_download_find_firmware_request),
 					 GB_FW_DOWNLOAD_TYPE_FIND_FIRMWARE, false);
@@ -186,6 +187,7 @@ void gb_fw_download_find_firmware(uint8_t req_id, const char *firmware_tag)
 
 	priv_data.req_id = req_id;
 	strncpy(req_data->firmware_tag, firmware_tag, sizeof(req_data->firmware_tag));
+	strncpy(req_data->format, format, sizeof(req_data->format));
 
 	gb_transport_message_send(req, GREYBUS_FW_DOWNLOAD_CPORT);
 	gb_message_dealloc(req);


### PR DESCRIPTION
- Linux kernel implementation of find firmware did not have format in the argument for some reason. This was not spec compliant.