### PR TITLE
Constify gb_drivers

### DIFF
--- a/subsys/greybus/control-gpb.c
+++ b/subsys/greybus/control-gpb.c
@@ -184,6 +184,6 @@ static void gb_control_handler(const void *priv, struct gb_message *msg, uint16_
 	}
 }
 
-struct gb_driver gb_control_driver = {
+const struct gb_driver gb_control_driver = {
 	.op_handler = gb_control_handler,
 };

--- a/subsys/greybus/fw_download.c
+++ b/subsys/greybus/fw_download.c
@@ -171,7 +171,7 @@ static void op_handler(const void *priv, struct gb_message *msg, uint16_t cport)
 	}
 }
 
-struct gb_driver gb_fw_download_driver = {
+const struct gb_driver gb_fw_download_driver = {
 	.op_handler = op_handler,
 };
 

--- a/subsys/greybus/fw_management.c
+++ b/subsys/greybus/fw_management.c
@@ -67,7 +67,7 @@ static void op_handler(const void *priv, struct gb_message *msg, uint16_t cport)
 	}
 }
 
-struct gb_driver gb_fw_mgmt_driver = {
+const struct gb_driver gb_fw_mgmt_driver = {
 	.op_handler = op_handler,
 };
 

--- a/subsys/greybus/gpio.c
+++ b/subsys/greybus/gpio.c
@@ -345,7 +345,7 @@ static void gb_gpio_disconnected(const void *priv)
 	gpio_remove_callback(data->dev, &data->cb);
 }
 
-struct gb_driver gb_gpio_driver = {
+const struct gb_driver gb_gpio_driver = {
 	.connected = gb_gpio_connected,
 	.disconnected = gb_gpio_disconnected,
 	.op_handler = gb_gpio_handler,

--- a/subsys/greybus/greybus-core.c
+++ b/subsys/greybus/greybus-core.c
@@ -99,7 +99,7 @@ uint8_t gb_errno_to_op_result(int err)
 
 static void gb_process_msg(struct gb_message *msg, uint16_t cport)
 {
-	struct gb_cport *cport_ptr = gb_cport_get(cport);
+	const struct gb_cport *cport_ptr = gb_cport_get(cport);
 
 	if (gb_message_type(msg) == GB_PING_TYPE) {
 		return gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
@@ -133,7 +133,7 @@ static void gb_pending_message_worker(void *p1, void *p2, void *p3)
 
 int greybus_rx_handler(uint16_t cport, struct gb_message *msg)
 {
-	struct gb_driver *drv;
+	const struct gb_driver *drv;
 	const struct gb_msg_with_cport item = {
 		.cport = cport,
 		.msg = msg,
@@ -155,7 +155,7 @@ int greybus_rx_handler(uint16_t cport, struct gb_message *msg)
 int gb_listen(uint16_t cport)
 {
 	const struct gb_transport_backend *transport = gb_transport_get_backend();
-	struct gb_cport *cport_ptr = gb_cport_get(cport);
+	const struct gb_cport *cport_ptr = gb_cport_get(cport);
 
 	if (!cport_ptr) {
 		LOG_ERR("Invalid cport number %u", cport);
@@ -173,7 +173,7 @@ int gb_listen(uint16_t cport)
 int gb_stop_listening(uint16_t cport)
 {
 	const struct gb_transport_backend *transport = gb_transport_get_backend();
-	struct gb_cport *cport_ptr = gb_cport_get(cport);
+	const struct gb_cport *cport_ptr = gb_cport_get(cport);
 
 	if (!cport_ptr) {
 		LOG_ERR("Invalid cport number %u", cport);
@@ -229,7 +229,7 @@ void gb_deinit(void)
 
 int gb_notify(uint16_t cport, enum gb_event event)
 {
-	struct gb_cport *cport_ptr = gb_cport_get(cport);
+	const struct gb_cport *cport_ptr = gb_cport_get(cport);
 
 	if (!cport_ptr) {
 		return -EINVAL;

--- a/subsys/greybus/greybus_cport.c
+++ b/subsys/greybus/greybus_cport.c
@@ -20,10 +20,10 @@
 
 LOG_MODULE_REGISTER(greybus_cport, CONFIG_GREYBUS_LOG_LEVEL);
 
-extern struct gb_driver gb_control_driver;
-extern struct gb_driver gb_i2c_driver;
-extern struct gb_driver gb_loopback_driver;
-extern struct gb_driver gb_log_driver;
+extern const struct gb_driver gb_control_driver;
+extern const struct gb_driver gb_i2c_driver;
+extern const struct gb_driver gb_loopback_driver;
+extern const struct gb_driver gb_log_driver;
 
 /* Reset the counter to 0 */
 enum {
@@ -181,7 +181,7 @@ static struct gb_cport cports[] = {
 
 BUILD_ASSERT(GREYBUS_CPORT_COUNT == ARRAY_SIZE(cports));
 
-struct gb_cport *gb_cport_get(uint16_t cport)
+const struct gb_cport *gb_cport_get(uint16_t cport)
 {
 	return (cport >= GREYBUS_CPORT_COUNT) ? NULL : &cports[cport];
 }

--- a/subsys/greybus/greybus_cport.h
+++ b/subsys/greybus/greybus_cport.h
@@ -10,13 +10,13 @@
 #include <greybus/greybus.h>
 
 struct gb_cport {
-	struct gb_driver *driver;
+	const struct gb_driver *driver;
 	const void *priv;
 	uint8_t bundle;
 	uint8_t protocol;
 };
 
-struct gb_cport *gb_cport_get(uint16_t cport);
+const struct gb_cport *gb_cport_get(uint16_t cport);
 
 /**
  * Initialize all cports.

--- a/subsys/greybus/greybus_fw_download.h
+++ b/subsys/greybus/greybus_fw_download.h
@@ -9,7 +9,7 @@
 
 #include <stdint.h>
 
-extern struct gb_driver gb_fw_download_driver;
+extern const struct gb_driver gb_fw_download_driver;
 
 void gb_fw_download_find_firmware(uint8_t req_id, const char *firmware_tag);
 

--- a/subsys/greybus/greybus_fw_mgmt.h
+++ b/subsys/greybus/greybus_fw_mgmt.h
@@ -9,7 +9,7 @@
 
 #include <stdint.h>
 
-extern struct gb_driver gb_fw_mgmt_driver;
+extern const struct gb_driver gb_fw_mgmt_driver;
 
 void gb_fw_mgmt_interface_fw_loaded(uint8_t id, uint8_t status, uint16_t major, uint16_t minor);
 

--- a/subsys/greybus/greybus_gpio.h
+++ b/subsys/greybus/greybus_gpio.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/drivers/gpio.h>
 
-extern struct gb_driver gb_gpio_driver;
+extern const struct gb_driver gb_gpio_driver;
 
 struct gb_gpio_driver_data {
 	struct gpio_callback cb;

--- a/subsys/greybus/greybus_lights.h
+++ b/subsys/greybus/greybus_lights.h
@@ -9,7 +9,7 @@
 
 #include <stdint.h>
 
-extern struct gb_driver gb_lights_driver;
+extern const struct gb_driver gb_lights_driver;
 
 struct gb_lights_driver_data {
 	uint8_t lights_num;

--- a/subsys/greybus/greybus_pwm.h
+++ b/subsys/greybus/greybus_pwm.h
@@ -10,7 +10,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-extern struct gb_driver gb_pwm_driver;
+extern const struct gb_driver gb_pwm_driver;
 
 struct gb_pwm_channel_data {
 	uint32_t duty;

--- a/subsys/greybus/greybus_raw_internal.h
+++ b/subsys/greybus/greybus_raw_internal.h
@@ -9,7 +9,7 @@
 
 #include <greybus/greybus_raw.h>
 
-extern struct gb_driver gb_raw_driver;
+extern const struct gb_driver gb_raw_driver;
 
 struct gb_raw_driver_data {
 	greybus_raw_cb_t cb;

--- a/subsys/greybus/greybus_spi.h
+++ b/subsys/greybus/greybus_spi.h
@@ -10,7 +10,7 @@
 #include <stdint.h>
 #include <greybus/greybus_protocols.h>
 
-extern struct gb_driver gb_spi_driver;
+extern const struct gb_driver gb_spi_driver;
 
 struct gb_spi_device_data {
 	struct gb_spi_device_config_response data;

--- a/subsys/greybus/greybus_uart.h
+++ b/subsys/greybus/greybus_uart.h
@@ -9,6 +9,6 @@
 
 #include <zephyr/drivers/uart.h>
 
-extern struct gb_driver gb_uart_driver;
+extern const struct gb_driver gb_uart_driver;
 
 #endif // _GREYBUS_UART_H_

--- a/subsys/greybus/i2c.c
+++ b/subsys/greybus/i2c.c
@@ -130,6 +130,6 @@ static void gb_i2c_handler(const void *priv, struct gb_message *msg, uint16_t cp
 	}
 }
 
-struct gb_driver gb_i2c_driver = {
+const struct gb_driver gb_i2c_driver = {
 	.op_handler = gb_i2c_handler,
 };

--- a/subsys/greybus/lights.c
+++ b/subsys/greybus/lights.c
@@ -170,6 +170,6 @@ static void gb_lights_handler(const void *priv, struct gb_message *msg, uint16_t
 	}
 }
 
-struct gb_driver gb_lights_driver = {
+const struct gb_driver gb_lights_driver = {
 	.op_handler = gb_lights_handler,
 };

--- a/subsys/greybus/log.c
+++ b/subsys/greybus/log.c
@@ -42,6 +42,6 @@ void gb_log_send_log(uint16_t len, const char *log)
 	gb_message_dealloc(msg);
 }
 
-struct gb_driver gb_log_driver = {
+const struct gb_driver gb_log_driver = {
 	.op_handler = op_handler,
 };

--- a/subsys/greybus/loopback.c
+++ b/subsys/greybus/loopback.c
@@ -62,6 +62,6 @@ static void gb_loopback_handler(const void *priv, struct gb_message *msg, uint16
 	}
 }
 
-struct gb_driver gb_loopback_driver = {
+const struct gb_driver gb_loopback_driver = {
 	.op_handler = gb_loopback_handler,
 };

--- a/subsys/greybus/platform/manifest.c
+++ b/subsys/greybus/platform/manifest.c
@@ -150,7 +150,7 @@ int manifest_create(uint8_t buf[], size_t len)
 	int ret, i;
 	struct greybus_manifest *mnfb;
 	struct greybus_descriptor *desc;
-	struct gb_cport *cport;
+	const struct gb_cport *cport;
 
 	if (len < manifest_size()) {
 		return -E2BIG;

--- a/subsys/greybus/pwm-protocol.c
+++ b/subsys/greybus/pwm-protocol.c
@@ -156,6 +156,6 @@ static void gb_pwm_handler(const void *priv, struct gb_message *msg, uint16_t cp
 	}
 }
 
-struct gb_driver gb_pwm_driver = {
+const struct gb_driver gb_pwm_driver = {
 	.op_handler = gb_pwm_handler,
 };

--- a/subsys/greybus/raw.c
+++ b/subsys/greybus/raw.c
@@ -44,14 +44,14 @@ static void op_handler(const void *priv, struct gb_message *msg, uint16_t cport)
 	}
 }
 
-struct gb_driver gb_raw_driver = {
+const struct gb_driver gb_raw_driver = {
 	.op_handler = op_handler,
 };
 
 int greybus_raw_register(greybus_raw_cb_t cb, void *priv)
 {
 	int i;
-	struct gb_cport *cport;
+	const struct gb_cport *cport;
 	struct gb_raw_driver_data *data;
 
 	for (i = 0; i < GREYBUS_RAW_CPORT_COUNT; ++i) {

--- a/subsys/greybus/spi.c
+++ b/subsys/greybus/spi.c
@@ -233,6 +233,6 @@ static void gb_spi_handler(const void *priv, struct gb_message *msg, uint16_t cp
 	}
 }
 
-struct gb_driver gb_spi_driver = {
+const struct gb_driver gb_spi_driver = {
 	.op_handler = gb_spi_handler,
 };

--- a/subsys/greybus/uart.c
+++ b/subsys/greybus/uart.c
@@ -264,7 +264,7 @@ static void gb_uart_disconnected(const void *priv)
 	uart_irq_rx_disable(dev);
 }
 
-struct gb_driver gb_uart_driver = {
+const struct gb_driver gb_uart_driver = {
 	.op_handler = gb_uart_handler,
 	.connected = gb_uart_connected,
 	.disconnected = gb_uart_disconnected,


### PR DESCRIPTION
- Since these structures are never modified after creation, we can use const for all it's uses.