### PR TITLE
Do not include transport by default

### DIFF
--- a/subsys/greybus/CMakeLists.txt
+++ b/subsys/greybus/CMakeLists.txt
@@ -6,7 +6,6 @@ zephyr_library()
 
 zephyr_library_sources(
   greybus_messages.c
-  greybus_transport.c
   greybus_heap.c
   platform/certificate.c
 )
@@ -14,6 +13,7 @@ zephyr_library_sources(
 # Node-specific files
 zephyr_library_sources_ifdef(
 	CONFIG_GREYBUS_NODE
+	greybus_transport.c
 	greybus-core.c
 	control-gpb.c
 	platform/manifest.c

--- a/subsys/greybus/Kconfig
+++ b/subsys/greybus/Kconfig
@@ -11,17 +11,19 @@ menuconfig GREYBUS
 
 if GREYBUS
 
+config GREYBUS_HEAP_MEM_POOL_SIZE
+	int "Heap for Greybus subsystem"
+	default 2048
+	help
+	  Heap memory pre-allocated for greybus subsystem
+
 config GREYBUS_NODE
 	bool "Enable greybus node support"
 	default y
 	help
 	  This option enables functionality to act as Greybus node.
 
-config GREYBUS_HEAP_MEM_POOL_SIZE
-	int "Heap for Greybus subsystem"
-	default 2048
-	help
-	  Heap memory pre-allocated for greybus subsystem
+if GREYBUS_NODE
 
 choice
 	prompt "Which transport shall be used for Greybus?"
@@ -41,8 +43,6 @@ config GREYBUS_XPORT_DUMMY
 	  This is intended for testing and tracking base greybus subsystem size.
 
 endchoice
-
-if GREYBUS_NODE
 
 config GREYBUS_VENDOR_STRING
 	string "Greybus Vendor String"


### PR DESCRIPTION
- After some testing, it seems like greybus_transport cannot be used in it's current form with SVC. So only include it when building for node.