### PR TITLE
Add APBridge implementation

### DIFF
--- a/include/greybus/apbridge.h
+++ b/include/greybus/apbridge.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2025 Ayush Singh BeagleBoard.org
+ *
+ * In a Greybus network, the component responsible for creating connections
+ * and routing messages between greybus host and greybus node is known as
+ * APBridge.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _GREYBUS_APBRIDGE_H_
+#define _GREYBUS_APBRIDGE_H_
+
+#include <greybus/greybus_messages.h>
+
+#define AP_MAX_NODES CONFIG_GREYBUS_APBRIDGE_CPORTS
+#define AP_INF_ID    1
+
+struct gb_interface;
+
+/**
+ * Callback for writing to an interface
+ *
+ * @param controller
+ * @param greybus message to send
+ * @param Cport to write to
+ *
+ * @return 0 if successful. Negative in case of error
+ */
+typedef int (*gb_controller_write_callback_t)(struct gb_interface *, struct gb_message *, uint16_t);
+
+/**
+ * Callback to create new connection with a Cport in the interface
+ *
+ * @param controller
+ * @param cport
+ *
+ * @return 0 if successful. Negative in case of error
+ */
+typedef int (*gb_controller_create_connection_t)(const struct gb_interface *, uint16_t);
+
+/**
+ * Callback to destroy connection with a Cport in the interface
+ *
+ * @param controller
+ * @param cport
+ */
+typedef void (*gb_controller_destroy_connection_t)(const struct gb_interface *, uint16_t);
+
+/**
+ * A greybus interface. Can have multiple Cports
+ *
+ * @param id: Interface ID
+ * @param write: a non-blocking write function. The ownership of message is
+ * transferred.
+ * @param ctrl_data: private controller data
+ */
+struct gb_interface {
+	gb_controller_write_callback_t write;
+	gb_controller_create_connection_t create_connection;
+	gb_controller_destroy_connection_t destroy_connection;
+	void *ctrl_data;
+	uint8_t id;
+};
+
+/**
+ * Initialize and start APBridge
+ *
+ * @return 0 in case of success.
+ * @return < 0 in case of error.
+ */
+int gb_apbridge_init(void);
+
+/*
+ * De-Initialize and stop APBridge.
+ */
+void gb_apbridge_deinit(void);
+
+/**
+ * Create connection between 2 interface cports.
+ *
+ * NOTE: It is only possible to create connection between AP-Node. Node-Node and AP-AP are not
+ * supported.
+ *
+ * @param intf1_id
+ * @param intf1_cport
+ * @param intf2_id
+ * @param intf2_cport
+ *
+ * @return 0 in case of success.
+ * @return < 0 in case of error.
+ */
+int gb_apbridge_connection_create(uint8_t intf1_id, uint16_t intf1_cport, uint8_t intf2_id,
+				  uint16_t intf2_cport);
+
+/**
+ * Destroy connection between 2 interface cports.
+ *
+ * @param intf1_id
+ * @param intf1_cport
+ * @param intf2_id
+ * @param intf2_cport
+ *
+ * @return 0 in case of success.
+ * @return < 0 in case of error.
+ */
+int gb_apbridge_connection_destroy(uint8_t intf1_id, uint16_t intf1_cport, uint8_t intf2_id,
+				   uint16_t intf2_cport);
+
+/**
+ * Send message between connected cports.
+ *
+ * Looks up the target connected inteface and sends the greybus message.
+ *
+ * @param intf_id: Interface ID of the origin.
+ * @param intf_cport: Interface CPort of the origin.
+ * @param msg: Message to send
+ *
+ * @return 0 in case of success.
+ * @return < 0 in case of error.
+ */
+int gb_apbridge_send(uint8_t intf_id, uint16_t intf_cport, struct gb_message *msg);
+
+/**
+ * Get greybus interface by ID;
+ */
+struct gb_interface *gb_interface_get(uint8_t id);
+
+/**
+ * Allocate greybus interface dynamically.
+ *
+ * @param write_cb
+ * @param create_connection_cb
+ * @param destroy_connection_cb
+ * @param ctrl_data
+ *
+ * @return NULL in case of error
+ */
+struct gb_interface *gb_interface_alloc(gb_controller_write_callback_t write_cb,
+					gb_controller_create_connection_t create_connection_cb,
+					gb_controller_destroy_connection_t destroy_connection_cb,
+					void *ctrl_data);
+
+/**
+ * De-allocate greybus interface
+ *
+ * Also registers greybus interface.
+ *
+ * @param intf
+ */
+void gb_interface_dealloc(struct gb_interface *intf);
+
+/**
+ * Add greybus interface to cache.
+ *
+ * @param intf
+ *
+ * @return 0 in case of success.
+ * @return < 0 in case of error.
+ */
+int gb_interface_add(struct gb_interface *intf);
+
+/**
+ * Remove greybus interface from cache
+ *
+ * @param id: Greybus interface ID
+ */
+void gb_interface_remove(uint8_t id);
+
+#endif // _GREYBUS_APBRIDGE_H_

--- a/subsys/greybus/CMakeLists.txt
+++ b/subsys/greybus/CMakeLists.txt
@@ -21,6 +21,13 @@ zephyr_library_sources_ifdef(
 	greybus_cport.c
 )
 
+# APBridge-specific files
+zephyr_library_sources_ifdef(
+	CONFIG_GREYBUS_APBRIDGE
+	apbridge.c
+	interfaces.c
+)
+
 if(CONFIG_GREYBUS_TLS_BUILTIN)
   set(gen_dir ${ZEPHYR_BINARY_DIR}/include/generated/)
 

--- a/subsys/greybus/Kconfig
+++ b/subsys/greybus/Kconfig
@@ -17,6 +17,21 @@ config GREYBUS_HEAP_MEM_POOL_SIZE
 	help
 	  Heap memory pre-allocated for greybus subsystem
 
+config GREYBUS_APBRIDGE
+	bool "Enable greybus apbridge implementation"
+	help
+	  This option enables software implementation of Greybus APBridge.
+
+if GREYBUS_APBRIDGE
+
+config GREYBUS_APBRIDGE_CPORTS
+	int "Maximum number of cports supported by APBridge"
+	default 32
+	help
+	  Specify the maximum number of cports supported by the APBridge
+
+endif
+
 config GREYBUS_NODE
 	bool "Enable greybus node support"
 	default y

--- a/subsys/greybus/apbridge.c
+++ b/subsys/greybus/apbridge.c
@@ -1,0 +1,165 @@
+#include <greybus/apbridge.h>
+#include <zephyr/sys/errno_private.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(greybus_apbridge, CONFIG_GREYBUS_LOG_LEVEL);
+
+struct node_ap_item {
+	struct gb_interface *node_intf;
+	uint16_t node_cport;
+};
+
+static struct node_ap_item node_ap_map[AP_MAX_NODES] = {0};
+
+static int node_ap_add(uint16_t ap_cport, uint16_t node_cport, struct gb_interface *node_intf)
+{
+	if (ap_cport >= ARRAY_SIZE(node_ap_map)) {
+		return -EOVERFLOW;
+	}
+
+	if (node_ap_map[ap_cport].node_intf) {
+		return -EALREADY;
+	}
+
+	node_ap_map[ap_cport].node_cport = node_cport;
+	node_ap_map[ap_cport].node_intf = node_intf;
+
+	return 0;
+}
+
+static int node_ap_remove(uint16_t ap_cport)
+{
+	if (ap_cport >= ARRAY_SIZE(node_ap_map)) {
+		return -EOVERFLOW;
+	}
+
+	node_ap_map[ap_cport].node_cport = 0;
+	node_ap_map[ap_cport].node_intf = NULL;
+
+	return 0;
+}
+
+static int node_to_ap_cport(uint8_t node_id, uint16_t node_cport)
+{
+	const struct node_ap_item *item;
+
+	for (size_t i = 0; i < ARRAY_SIZE(node_ap_map); i++) {
+		item = &node_ap_map[i];
+
+		if (item->node_intf && item->node_intf->id == node_id &&
+		    item->node_cport == node_cport) {
+			return i;
+		}
+	}
+
+	return -EINVAL;
+}
+
+int gb_apbridge_init(void)
+{
+	return 0;
+}
+
+void gb_apbridge_deinit(void)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(node_ap_map); ++i) {
+		node_ap_map[i].node_cport = 0;
+		node_ap_map[i].node_intf = NULL;
+	}
+}
+
+int gb_apbridge_connection_create(uint8_t intf1_id, uint16_t intf1_cport, uint8_t intf2_id,
+				  uint16_t intf2_cport)
+{
+	struct gb_interface *intf;
+	uint8_t node_id;
+	uint16_t ap_cport, node_cport;
+	int ret;
+
+	if (intf1_id == AP_INF_ID) {
+		node_id = intf2_id;
+		node_cport = intf2_cport;
+		ap_cport = intf1_cport;
+	} else if (intf2_id == AP_INF_ID) {
+		node_id = intf1_id;
+		node_cport = intf1_cport;
+		ap_cport = intf2_cport;
+	} else {
+		LOG_ERR("Cannot create connection between two non-AP");
+		return -EINVAL;
+	}
+
+	intf = gb_interface_get(node_id);
+	if (!intf) {
+		LOG_ERR("Failed to find node interface");
+		return -EINVAL;
+	}
+
+	ret = intf->create_connection(intf, node_cport);
+	if (ret < 0) {
+		LOG_ERR("Failed to create node connection");
+		return ret;
+	}
+
+	ret = node_ap_add(ap_cport, node_cport, intf);
+	if (ret < 0) {
+		LOG_ERR("Failed to add AP to node");
+		return ret;
+	}
+
+	return 0;
+}
+
+int gb_apbridge_connection_destroy(uint8_t intf1_id, uint16_t intf1_cport, uint8_t intf2_id,
+				   uint16_t intf2_cport)
+{
+	uint8_t node_id;
+	uint16_t ap_cport, node_cport;
+	const struct gb_interface *intf;
+
+	if (intf1_id == AP_INF_ID) {
+		node_id = intf2_id;
+		node_cport = intf2_cport;
+		ap_cport = intf1_cport;
+	} else if (intf2_id == AP_INF_ID) {
+		node_id = intf1_id;
+		node_cport = intf1_cport;
+		ap_cport = intf2_cport;
+	} else {
+		LOG_ERR("Cannot destroy connection between two non-AP");
+		return -EINVAL;
+	}
+
+	intf = gb_interface_get(node_id);
+	/* Ignore if intf has already been cleaned up */
+	if (intf) {
+		intf->destroy_connection(intf, node_cport);
+	}
+
+	node_ap_remove(ap_cport);
+
+	return 0;
+}
+
+int gb_apbridge_send(uint8_t intf_id, uint16_t intf_cport, struct gb_message *msg)
+{
+	struct gb_interface *intf;
+	uint16_t target_cport;
+	int ret;
+
+	if (intf_id == AP_INF_ID) {
+		intf = node_ap_map[intf_cport].node_intf;
+		target_cport = node_ap_map[intf_cport].node_cport;
+	} else {
+		ret = node_to_ap_cport(intf_id, intf_cport);
+		if (ret < 0) {
+			LOG_ERR("Failed to find AP cport");
+			return ret;
+		}
+
+		intf = gb_interface_get(AP_INF_ID);
+		target_cport = ret;
+	}
+
+	return intf->write(intf, msg, target_cport);
+}

--- a/subsys/greybus/interfaces.c
+++ b/subsys/greybus/interfaces.c
@@ -1,0 +1,116 @@
+#include <greybus/apbridge.h>
+#include <zephyr/sys/errno_private.h>
+#include "greybus_heap.h"
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/mutex.h>
+
+/*
+ * Reserve interface 0 for SVC
+ * Reserve interface 1 for AP
+ */
+#define INTF_START 2
+
+static struct gb_interface *intfs[AP_MAX_NODES];
+K_MUTEX_DEFINE(intfs_mutex);
+
+static int new_interface_id(void)
+{
+	int ret, i;
+
+	ret = k_mutex_lock(&intfs_mutex, K_NO_WAIT);
+	if (ret < 0) {
+		return -EBUSY;
+	}
+
+	ret = -EOVERFLOW;
+
+	for (i = INTF_START; i < ARRAY_SIZE(intfs); i++) {
+		if (!intfs[i]) {
+			ret = i;
+			goto unlock;
+		}
+	}
+
+unlock:
+	k_mutex_unlock(&intfs_mutex);
+	return ret;
+}
+
+int gb_interface_add(struct gb_interface *intf)
+{
+	int ret;
+
+	ret = k_mutex_lock(&intfs_mutex, K_NO_WAIT);
+	if (ret < 0) {
+		return -EBUSY;
+	}
+
+	if (intfs[intf->id]) {
+		ret = -EALREADY;
+	} else {
+		ret = 0;
+		intfs[intf->id] = intf;
+	}
+
+	k_mutex_unlock(&intfs_mutex);
+
+	return ret;
+}
+
+void gb_interface_remove(uint8_t id)
+{
+	k_mutex_lock(&intfs_mutex, K_FOREVER);
+
+	intfs[id] = NULL;
+
+	k_mutex_unlock(&intfs_mutex);
+}
+
+struct gb_interface *gb_interface_alloc(gb_controller_write_callback_t write_cb,
+					gb_controller_create_connection_t create_connection_cb,
+					gb_controller_destroy_connection_t destroy_connection_cb,
+					void *ctrl_data)
+{
+	int ret;
+	struct gb_interface *intf;
+
+	ret = k_mutex_lock(&intfs_mutex, K_NO_WAIT);
+	if (ret < 0) {
+		return NULL;
+	}
+
+	ret = new_interface_id();
+	if (ret < 0) {
+		k_mutex_unlock(&intfs_mutex);
+		return NULL;
+	}
+
+	intf = gb_alloc(sizeof(struct gb_interface));
+	if (!intf) {
+		k_mutex_unlock(&intfs_mutex);
+		return intf;
+	}
+
+	intf->id = ret;
+	intf->create_connection = create_connection_cb;
+	intf->destroy_connection = destroy_connection_cb;
+	intf->write = write_cb;
+	intf->ctrl_data = ctrl_data;
+
+	gb_interface_add(intf);
+
+	k_mutex_unlock(&intfs_mutex);
+
+	return intf;
+}
+
+void gb_interface_dealloc(struct gb_interface *intf)
+{
+	gb_interface_remove(intf->id);
+	gb_free(intf);
+}
+
+struct gb_interface *gb_interface_get(uint8_t id)
+{
+	return intfs[id];
+}


### PR DESCRIPTION
In a greybus network, APBridge is responsible for sending messages across connections between cports. This commit provides Zephyr implementation for APBridge. The max number of interfaces supported can be set using a kconfig variable.

Tested with BeaglePlay and BeagleConnect Freedom.