### PR TITLE
include: greybus: apbridge: Change create and destroy API

### DIFF
--- a/include/greybus/apbridge.h
+++ b/include/greybus/apbridge.h
@@ -38,7 +38,7 @@ typedef int (*gb_controller_write_callback_t)(struct gb_interface *, struct gb_m
  *
  * @return 0 if successful. Negative in case of error
  */
-typedef int (*gb_controller_create_connection_t)(const struct gb_interface *, uint16_t);
+typedef int (*gb_controller_create_connection_t)(struct gb_interface *, uint16_t);
 
 /**
  * Callback to destroy connection with a Cport in the interface
@@ -46,7 +46,7 @@ typedef int (*gb_controller_create_connection_t)(const struct gb_interface *, ui
  * @param controller
  * @param cport
  */
-typedef void (*gb_controller_destroy_connection_t)(const struct gb_interface *, uint16_t);
+typedef void (*gb_controller_destroy_connection_t)(struct gb_interface *, uint16_t);
 
 /**
  * A greybus interface. Can have multiple Cports

--- a/subsys/greybus/apbridge.c
+++ b/subsys/greybus/apbridge.c
@@ -117,8 +117,8 @@ int gb_apbridge_connection_destroy(uint8_t intf1_id, uint16_t intf1_cport, uint8
 				   uint16_t intf2_cport)
 {
 	uint8_t node_id;
+	struct gb_interface *intf;
 	uint16_t ap_cport, node_cport;
-	const struct gb_interface *intf;
 
 	if (intf1_id == AP_INF_ID) {
 		node_id = intf2_id;


### PR DESCRIPTION
- Allow the functions to modify gb_interface structure. Specifically, the ctrl_data pointer. For example, one can use this field to store an integer directly, instead of pointing to something that stores the integer.