### PR TITLE
tests: loopback & gpio: add edge-case and boundary validation

### DIFF
--- a/tests/greybus/integration/gpio/src/main.c
+++ b/tests/greybus/integration/gpio/src/main.c
@@ -181,3 +181,20 @@ ZTEST(greybus_gpio_tests, test_set_value)
 
 	zassert_equal(gpio_emul_output_get(dev, 0), 0, "Pin was not configured as output");
 }
+
+ZTEST(greybus_gpio_tests, test_invalid_pin_index)
+{
+	struct gb_msg_with_cport resp;
+	struct gb_gpio_get_direction_request *req_data;
+	struct gb_message *msg =
+		gb_message_request_alloc(sizeof(*req_data), GB_GPIO_TYPE_GET_DIRECTION, false);
+
+	req_data = (struct gb_gpio_get_direction_request *)msg->payload;
+	req_data->which = 255;
+
+	greybus_rx_handler(1, gb_message_copy(msg));
+	resp = gb_transport_get_message();
+	zassert_false(gb_message_is_success(resp.msg),
+		      "Driver should have rejected invalid pin index 255");
+	gb_message_dealloc(msg);
+}

--- a/tests/greybus/integration/loopback/src/main.c
+++ b/tests/greybus/integration/loopback/src/main.c
@@ -92,3 +92,56 @@ ZTEST(greybus_loopback_tests, test_transfer)
 	gb_message_dealloc(req);
 	gb_message_dealloc(resp.msg);
 }
+
+ZTEST(greybus_loopback_tests, test_zero_length_transfer)
+{
+	struct gb_msg_with_cport resp;
+	struct gb_message *req = gb_message_request_alloc(
+		sizeof(struct gb_loopback_transfer_request), GB_LOOPBACK_TYPE_TRANSFER, false);
+	struct gb_loopback_transfer_request *req_data =
+		(struct gb_loopback_transfer_request *)req->payload;
+
+	req_data->len = sys_cpu_to_le32(0);
+	// first we send an empty request
+	greybus_rx_handler(1, req);
+	resp = gb_transport_get_message(); // receiving
+	zassert_true(gb_message_is_success(resp.msg), "Zero length transfer failed");
+	zassert_equal(gb_message_type(resp.msg), GB_RESPONSE(GB_LOOPBACK_TYPE_TRANSFER),
+		      "Invalid response type for zero-length transfer");
+	zassert_equal(gb_message_payload_len(resp.msg), sizeof(struct gb_loopback_transfer_request),
+		      "Response should contain header size");
+
+	struct gb_loopback_transfer_request *resp_data =
+		(struct gb_loopback_transfer_request *)resp.msg->payload;
+
+	zassert_equal(sys_le32_to_cpu(resp_data->len), 0, "Response len field should be 0");
+	// cleanup
+	gb_message_dealloc(resp.msg);
+	gb_message_dealloc(req);
+}
+
+ZTEST(greybus_loopback_tests, test_invalid_operation)
+{
+	struct gb_msg_with_cport resp;
+	struct gb_message *req = gb_message_request_alloc(0, 0x7F, false);
+
+	greybus_rx_handler(1, req);
+	resp = gb_transport_get_message();
+
+	// validation
+	zassert_false(gb_message_is_success(resp.msg), "Should fail for invalid op");
+	zassert_equal(gb_message_type(resp.msg), GB_RESPONSE(0x7F), "Type mismatch");
+	gb_message_dealloc(resp.msg);
+}
+
+ZTEST(greybus_loopback_tests, test_rapid_pings)
+{
+	for (int i = 0; i < 20; i++) {
+		struct gb_msg_with_cport resp;
+		struct gb_message *req = gb_message_request_alloc(0, GB_LOOPBACK_TYPE_PING, false);
+		greybus_rx_handler(1, req);
+		resp = gb_transport_get_message();
+		zassert_true(gb_message_is_success(resp.msg), "Ping %d failed in rapid fire", i);
+		gb_message_dealloc(resp.msg);
+	}
+}


### PR DESCRIPTION
Hi @Ayush1325 ! I've been working on expanding the integration tests for Greybus on native_sim.

This PR adds several edge-case checks:
        1. Loopback: Added zero-length transfers, invalid operation IDs (0x7F), and a simple rapid-ping test.
        2. GPIO: Added a boundary check for invalid pin indices.

 NOTE:
While I was writing these tests, I started digging into the driver code to see how the messages were being handled. I noticed a discrepancy in `subsys/greybus/gpio.c:86 `within the `gb_gpio_get_direction` function (and likely other handlers like `gb_gpio_set_value`).

The current implementation takes the pin index (request->which) from the Greybus message and passes it directly to the Zephyr GPIO API:
`resp_data.direction = gpio_pin_is_input(dev, request->which);`

Since there’s no bounds check against `data->ngpios`, my test for Pin 255 returns `SUCCESS` instead of an error, even though that pin doesn't exist on the simulated hardware. I've included the failing test for now to highlight this.

If you agree this should be validated at the Greybus layer, I’m happy to send a follow-up PR to add those checks across the GPIO service.

Verified with `west build` on `native_sim`.