### PR TITLE
greybus: Replace non-standard DEBUGASSERT with Zephyr __ASSERT

### DIFF
--- a/subsys/greybus/camera.c
+++ b/subsys/greybus/camera.c
@@ -480,7 +480,7 @@ err_free_info:
  */
 static void gb_camera_exit(unsigned int cport, struct gb_bundle *bundle)
 {
-	DEBUGASSERT(cport == info->cport);
+	__ASSERT(cport == info->cport, "cport mismatch");
 
 	device_close(info->dev);
 

--- a/subsys/greybus/hid.c
+++ b/subsys/greybus/hid.c
@@ -175,7 +175,7 @@ static uint8_t gb_hid_get_descriptor(struct gb_operation *operation)
 	int ret = 0;
 
 	bundle = gb_operation_get_bundle(operation);
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	hid_info = bundle->priv;
 
@@ -221,7 +221,7 @@ static uint8_t gb_hid_get_report_descriptor(struct gb_operation *operation)
 	int ret = 0;
 
 	bundle = gb_operation_get_bundle(operation);
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	hid_info = bundle->priv;
 
@@ -255,7 +255,7 @@ static uint8_t gb_hid_power_on(struct gb_operation *operation)
 	int ret = 0;
 
 	bundle = gb_operation_get_bundle(operation);
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	hid_info = bundle->priv;
 
@@ -284,7 +284,7 @@ static uint8_t gb_hid_power_off(struct gb_operation *operation)
 	int ret = 0;
 
 	bundle = gb_operation_get_bundle(operation);
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	hid_info = bundle->priv;
 
@@ -323,7 +323,7 @@ static uint8_t gb_hid_get_report(struct gb_operation *operation)
 	bundle = gb_operation_get_bundle(operation);
 	request = gb_operation_get_request_payload(operation);
 
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	if (gb_operation_get_request_payload_size(operation) < sizeof(*request)) {
 		LOG_ERR("dropping short message");
@@ -378,7 +378,7 @@ static uint8_t gb_hid_set_report(struct gb_operation *operation)
 	bundle = gb_operation_get_bundle(operation);
 	request = gb_operation_get_request_payload(operation);
 
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	if (gb_operation_get_request_payload_size(operation) < sizeof(*request)) {
 		LOG_ERR("dropping short message");
@@ -422,7 +422,7 @@ static int hid_event_callback_routine(struct device *dev, void *data, uint8_t re
 	struct gb_hid_info *hid_info;
 	struct op_node *node;
 
-	DEBUGASSERT(data);
+	__ASSERT(data != NULL, "data pointer is NULL");
 	hid_info = data;
 
 	if (!hid_info->report_node) {
@@ -643,7 +643,7 @@ static int gb_hid_init(unsigned int cport, struct gb_bundle *bundle)
 	struct gb_hid_info *hid_info;
 	int ret;
 
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	hid_info = zalloc(sizeof(*hid_info));
 	if (!hid_info) {
@@ -704,7 +704,7 @@ static void gb_hid_exit(unsigned int cport, struct gb_bundle *bundle)
 {
 	struct gb_hid_info *hid_info;
 
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 	hid_info = bundle->priv;
 
 	if (!hid_info) {

--- a/subsys/greybus/power_supply.c
+++ b/subsys/greybus/power_supply.c
@@ -67,7 +67,7 @@ static int event_callback(void *data, uint8_t psy_id, uint8_t event)
 	struct gb_power_supply_event_request *request;
 	struct gb_power_supply_info *info;
 
-	DEBUGASSERT(data);
+	__ASSERT(data != NULL, "data pointer is NULL");
 	info = data;
 
 	operation = gb_operation_create(info->cport, GB_POWER_SUPPLY_TYPE_EVENT, sizeof(*request));
@@ -126,7 +126,7 @@ static uint8_t gb_power_supply_get_supplies(struct gb_operation *operation)
 	uint8_t supplies_count = 0;
 
 	bundle = gb_operation_get_bundle(operation);
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	response = gb_operation_alloc_response(operation, sizeof(*response));
 	if (!response) {
@@ -158,7 +158,7 @@ static uint8_t gb_power_supply_get_description(struct gb_operation *operation)
 	int ret = 0;
 
 	bundle = gb_operation_get_bundle(operation);
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	request = gb_operation_get_request_payload(operation);
 
@@ -206,7 +206,7 @@ static uint8_t gb_power_supply_get_prop_descriptors(struct gb_operation *operati
 	uint8_t properties_count = 0;
 
 	bundle = gb_operation_get_bundle(operation);
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	request = gb_operation_get_request_payload(operation);
 
@@ -269,7 +269,7 @@ static uint8_t gb_power_supply_get_property(struct gb_operation *operation)
 	uint8_t property = 0;
 
 	bundle = gb_operation_get_bundle(operation);
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	request = gb_operation_get_request_payload(operation);
 
@@ -313,7 +313,7 @@ static uint8_t gb_power_supply_set_property(struct gb_operation *operation)
 	uint8_t property = 0;
 
 	bundle = gb_operation_get_bundle(operation);
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	request = gb_operation_get_request_payload(operation);
 
@@ -347,7 +347,7 @@ static int gb_power_supply_init(unsigned int cport, struct gb_bundle *bundle)
 	struct gb_power_supply_info *info;
 	int ret;
 
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	info = zalloc(sizeof(*info));
 	if (info == NULL) {
@@ -391,10 +391,10 @@ static void gb_power_supply_exit(unsigned int cport, struct gb_bundle *bundle)
 {
 	struct gb_power_supply_info *info;
 
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 	info = bundle->priv;
 
-	DEBUGASSERT(cport == info->cport);
+	__ASSERT(cport == info->cport, "cport mismatch");
 
 	device_power_supply_attach_callback(bundle->dev, NULL, NULL);
 

--- a/subsys/greybus/sdio.c
+++ b/subsys/greybus/sdio.c
@@ -91,7 +91,7 @@ static int event_callback(void *data, uint8_t event)
 	struct gb_sdio_event_request *request;
 	struct gb_sdio_info *info;
 
-	DEBUGASSERT(data);
+	__ASSERT(data != NULL, "data pointer is NULL");
 	info = data;
 
 	operation = gb_operation_create(info->cport, GB_SDIO_TYPE_EVENT, sizeof(*request));
@@ -150,7 +150,7 @@ static uint8_t gb_sdio_protocol_get_capabilities(struct gb_operation *operation)
 	int ret;
 
 	bundle = gb_operation_get_bundle(operation);
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	ret = device_sdio_get_capabilities(bundle->dev, &cap);
 	if (ret) {
@@ -205,7 +205,7 @@ static uint8_t gb_sdio_protocol_set_ios(struct gb_operation *operation)
 	int ret;
 
 	bundle = gb_operation_get_bundle(operation);
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	request = gb_operation_get_request_payload(operation);
 
@@ -248,7 +248,7 @@ static uint8_t gb_sdio_protocol_command(struct gb_operation *operation)
 	int i, ret;
 
 	bundle = gb_operation_get_bundle(operation);
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	request = gb_operation_get_request_payload(operation);
 
@@ -324,7 +324,7 @@ static uint8_t gb_sdio_protocol_transfer(struct gb_operation *operation)
 	int ret;
 
 	bundle = gb_operation_get_bundle(operation);
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	request = gb_operation_get_request_payload(operation);
 
@@ -388,7 +388,7 @@ static int gb_sdio_init(unsigned int cport, struct gb_bundle *bundle)
 	struct gb_sdio_info *info;
 	int ret;
 
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 
 	info = zalloc(sizeof(*info));
 	if (info == NULL) {
@@ -431,10 +431,10 @@ static void gb_sdio_exit(unsigned int cport, struct gb_bundle *bundle)
 {
 	struct gb_sdio_info *info;
 
-	DEBUGASSERT(bundle);
+	__ASSERT(bundle != NULL, "bundle is NULL");
 	info = bundle->priv;
 
-	DEBUGASSERT(cport == info->cport);
+	__ASSERT(cport == info->cport, "cport mismatch");
 
 	device_sdio_attach_callback(bundle->dev, NULL, NULL);
 


### PR DESCRIPTION
Replace all instances of DEBUGASSERT (non-Zephyr API) with the standard Zephyr __ASSERT macro across multiple protocol implementations. Each assertion now includes a descriptive message for better debugging This improves code portability and follows Zephyr coding standards.