### PR TITLE
spi: Fix device_config fallback to use master config

### DIFF
--- a/subsys/greybus/greybus_cport.c
+++ b/subsys/greybus/greybus_cport.c
@@ -17,6 +17,7 @@
 #include "greybus_fw_mgmt.h"
 #include "greybus_internal.h"
 #include "greybus_raw_internal.h"
+#include <zephyr/devicetree/spi.h>
 
 LOG_MODULE_REGISTER(greybus_cport, CONFIG_GREYBUS_LOG_LEVEL);
 
@@ -54,6 +55,19 @@ enum {
 	static struct gb_spi_driver_data gb_spi_priv_data_##_idx = {                               \
 		.dev = DEVICE_DT_GET(DT_PHANDLE_BY_IDX(_node_id, _prop, _idx)),                    \
 		.devices = NULL,                                                                   \
+		.master_cfg = {                                                                    \
+			.min_speed_hz = 738,                                                       \
+			.max_speed_hz = DT_PROP_OR(DT_PHANDLE_BY_IDX(_node_id, _prop, _idx),      \
+						    clock_frequency, 24000000),                  \
+			.mode = 0,                                                                 \
+			.flags = 0,                                                                \
+			.num_chipselect = DT_SPI_HAS_CS_GPIOS(                                    \
+				DT_PHANDLE_BY_IDX(_node_id, _prop, _idx))                          \
+						  ? DT_SPI_NUM_CS_GPIOS(                            \
+							  DT_PHANDLE_BY_IDX(_node_id, _prop, _idx)) \
+						  : 1,                                               \
+		},                                                                                 \
+		.default_bits_per_word = 0,                                                       \
 		.device_num = 0,                                                                   \
 	};
 

--- a/subsys/greybus/greybus_spi.h
+++ b/subsys/greybus/greybus_spi.h
@@ -20,6 +20,8 @@ struct gb_spi_device_data {
 struct gb_spi_driver_data {
 	const struct gb_spi_device_data *devices;
 	const struct device *dev;
+	struct gb_spi_master_config_response master_cfg;
+	uint8_t default_bits_per_word;
 	uint8_t device_num;
 };
 

--- a/subsys/greybus/spi.c
+++ b/subsys/greybus/spi.c
@@ -42,18 +42,8 @@ LOG_MODULE_REGISTER(greybus_spi, CONFIG_GREYBUS_LOG_LEVEL);
 static void gb_spi_protocol_master_config(uint16_t cport, struct gb_message *req,
 					  const struct gb_spi_driver_data *data)
 {
-	ARG_UNUSED(data);
-
-	/* TODO: Zephyr should provide API to get these details */
-	const struct gb_spi_master_config_response resp_data = {
-		.min_speed_hz = 738,
-		.max_speed_hz = 24000000,
-		.mode = 0,
-		.flags = 0,
-		.num_chipselect = 1,
-	};
-
-	gb_transport_message_response_success_send(req, &resp_data, sizeof(resp_data), cport);
+	gb_transport_message_response_success_send(req, &data->master_cfg, sizeof(data->master_cfg),
+						   cport);
 }
 
 /**
@@ -73,19 +63,16 @@ static void gb_spi_protocol_device_config(uint16_t cport, struct gb_message *req
 	strncpy(dev_data.name, data->dev->name, sizeof(dev_data.name));
 
 	for (i = 0; i < data->device_num; i++) {
-		if (data->device_num == req_data->chip_select) {
+		if (i == req_data->chip_select) {
 			return gb_transport_message_response_success_send(
 				req, &data->devices[req_data->chip_select].data, sizeof(dev_data),
 				cport);
 		}
 	}
 
-	/* Use normal spi dev device
-	 * TODO: Need to be the same as master config
-	 */
-	dev_data.max_speed_hz = 24000000;
-	dev_data.mode = 0;
-	dev_data.bits_per_word = 0;
+	dev_data.max_speed_hz = data->master_cfg.max_speed_hz;
+	dev_data.mode = data->master_cfg.mode;
+	dev_data.bits_per_word = data->default_bits_per_word;
 	dev_data.device_type = GB_SPI_SPI_DEV;
 
 	gb_transport_message_response_success_send(req, &dev_data, sizeof(dev_data), cport);


### PR DESCRIPTION
- Fixed SPI TODO by removing hardcoded fallback device config values and reusing master config from `gb_spi_driver_data`.

- Added per-controller SPI master config storage in cport private data, initialized from DT (clock-frequency, CS count) with similar defaults mentioned in the previous code.

- Updated master config response to use the same stored config, keeping master config and fallback device config consistent.

- Fixed chip-select matching bug in `gb_spi_protocol_device_config` (`i == chip_select`).