### PR TITLE
subsys: greybus: migrate to TLS_CREDENTIAL_PUBLIC_CERTIFICATE

### DIFF
--- a/subsys/greybus/platform/certificate.c
+++ b/subsys/greybus/platform/certificate.c
@@ -55,7 +55,7 @@ int greybus_tls_init(void)
 
 		LOG_DBG("Adding Server Certificate (Public Key) (%zu bytes)",
 			sizeof(greybus_tls_builtin_server_cert));
-		r = tls_credential_add(GB_TLS_SERVER_CERT_TAG, TLS_CREDENTIAL_SERVER_CERTIFICATE,
+		r = tls_credential_add(GB_TLS_SERVER_CERT_TAG, TLS_CREDENTIAL_PUBLIC_CERTIFICATE,
 				       greybus_tls_builtin_server_cert,
 				       sizeof(greybus_tls_builtin_server_cert));
 		if (r < 0) {


### PR DESCRIPTION
Recent updates in the upstream Zephyr repository  has renamed the `TLS_CREDENTIAL_SERVER_CERTIFICATE` macro to `TLS_CREDENTIAL_PUBLIC_CERTIFICATE`. Because GitHub Actions pulls the latest Zephyr tree, this is currently causing compilation failures across all `native_sim` integration tests (throwing `undeclared (first use in this function)` and `invalid use of void expression` errors).

Replaced all instances of `TLS_CREDENTIAL_SERVER_CERTIFICATE` with `TLS_CREDENTIAL_PUBLIC_CERTIFICATE` to align with current Zephyr networking API standards.