### PR TITLE
greybus: camera: implement dynamic stream configuration and capture handlers

### DIFF
--- a/drivers/video/fake_camera.c
+++ b/drivers/video/fake_camera.c
@@ -112,7 +112,6 @@ static int cam_get_format(const struct device *dev, struct video_format *fmt)
 
 static int cam_flush(const struct device *dev, bool cancel)
 {
-
 	/* For the emulator, we just log it and return success- written for the ztest suite */
 	LOG_INF("Stream flushed (cancel: %d)", cancel);
 	return 0;

--- a/drivers/video/fake_camera.c
+++ b/drivers/video/fake_camera.c
@@ -110,6 +110,14 @@ static int cam_get_format(const struct device *dev, struct video_format *fmt)
 	return 0;
 }
 
+static int cam_flush(const struct device *dev, bool cancel)
+{
+
+	/* For the emulator, we just log it and return success- written for the ztest suite */
+	LOG_INF("Stream flushed (cancel: %d)", cancel);
+	return 0;
+}
+
 static DEVICE_API(video, cam_driver_api) = {
 	.set_format = cam_set_format,
 	.get_format = cam_get_format,
@@ -117,6 +125,7 @@ static DEVICE_API(video, cam_driver_api) = {
 	.set_stream = cam_set_stream,
 	.enqueue = cam_enqueue,
 	.dequeue = cam_dequeue,
+	.flush = cam_flush,
 };
 
 static int cam_init(const struct device *dev)

--- a/subsys/greybus/camera.c
+++ b/subsys/greybus/camera.c
@@ -161,33 +161,108 @@ static void gb_camera_capabilities(uint16_t cport, struct gb_message *msg,
  * @param msg- incoming gb message request
  * @param data- pointer to camera driver data
  */
-static void gb_camera_configure_streams(uint16_t cport, struct gb_message *msg, const struct gb_camera_driver_data *data)
+static void gb_camera_configure_streams(uint16_t cport, struct gb_message *msg,
+					const struct gb_camera_driver_data *data)
 {
-    struct gb_camera_driver_data *drv_data = (struct gb_camera_driver_data *)data;
-    struct video_format fmt;
-    int ret;
+	struct gb_camera_driver_data *drv_data = (struct gb_camera_driver_data *)data;
+	struct video_format hw_fmt;
+	struct gb_camera_configure_streams_request *req;
+	struct gb_camera_configure_streams_response *resp;
+	struct gb_camera_stream_config_request *stream_req;
+	struct gb_camera_stream_config_response *stream_resp;
+	size_t expected_req_size, resp_size, payload_size;
+	uint64_t max_size;
+	uint16_t req_width, req_height, req_format;
+	int ret, i;
+	uint8_t resp_flags = 0;
 
-    if (drv_data == NULL || drv_data->info.state < STATE_UNCONFIGURED) {
-        gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
-        return;
-    }
+	if (drv_data == NULL || drv_data->info.state < STATE_UNCONFIGURED) {
+		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
+		return;
+	}
 
-    /*TODO- Parse the requested resolution from the incoming msg payload */
-    /*for now, we are hardcoding to a format that we know the driver supports */
-    fmt.pixelformat = VIDEO_PIX_FMT_JPEG;
-    fmt.width = 640;
-    fmt.height = 480;
-    fmt.pitch = 640 * 2; 
+	payload_size = gb_hdr_message_len(&msg->header) - sizeof(struct gb_operation_msg_hdr);
 
-    ret = video_set_format(drv_data->dev, &fmt);
-    if (ret) {
-        gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
-        return;
-    }
+	if (payload_size < sizeof(*req)) {
+		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
+		return;
+	}
 
-    drv_data->info.state = STATE_CONFIGURED;
+	req = (struct gb_camera_configure_streams_request *)msg->payload;
 
-    gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
+	if (req->num_streams == 0 || req->num_streams > GB_CAMERA_MAX_STREAMS) {
+		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
+		return;
+	}
+
+	expected_req_size = sizeof(*req) + (req->num_streams * sizeof(*stream_req));
+	if (payload_size != expected_req_size) {
+		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
+		return;
+	}
+	resp_size = sizeof(*resp) + (req->num_streams * sizeof(*stream_resp));
+	resp = gb_alloc(resp_size);
+	if (!resp) {
+		gb_transport_message_empty_response_send(msg, GB_OP_NO_MEMORY, cport);
+		return;
+	}
+	memset(resp, 0, resp_size);
+
+	for (i = 0; i < req->num_streams; i++) {
+		stream_req = &req->config[i];
+		stream_resp = &resp->config[i];
+
+		req_width = sys_le16_to_cpu(stream_req->width);
+		req_height = sys_le16_to_cpu(stream_req->height);
+		req_format = sys_le16_to_cpu(stream_req->format);
+
+		if (req_width == 0 || req_height == 0) {
+			gb_free(resp);
+			gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
+			return;
+		}
+
+		if (req_format != GB_CAMERA_CAP_FMT_JPEG) {
+			resp_flags |= GB_CAMERA_CONFIGURE_STREAMS_ADJUSTED;
+			req_format = GB_CAMERA_CAP_FMT_JPEG;
+		}
+
+		if (i == 0) {
+			hw_fmt.pixelformat = VIDEO_PIX_FMT_JPEG;
+			hw_fmt.width = req_width;
+			hw_fmt.height = req_height;
+			hw_fmt.pitch = 0;
+		} else {
+			resp_flags |= GB_CAMERA_CONFIGURE_STREAMS_ADJUSTED;
+		}
+
+		stream_resp->width = sys_cpu_to_le16(req_width);
+		stream_resp->height = sys_cpu_to_le16(req_height);
+		stream_resp->format = sys_cpu_to_le16(req_format);
+
+		max_size = (uint64_t)req_width * req_height * 2;
+
+		if (max_size > UINT32_MAX) {
+			max_size = UINT32_MAX;
+		}
+
+		stream_resp->max_size = sys_cpu_to_le32((uint32_t)max_size);
+	}
+
+	ret = video_set_format(drv_data->dev, &hw_fmt);
+	if (ret) {
+		gb_free(resp);
+		gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
+		return;
+	}
+
+	resp->num_streams = req->num_streams;
+	resp->flags = resp_flags;
+
+	drv_data->info.state = STATE_CONFIGURED;
+
+	gb_transport_message_response_success_send(msg, resp, resp_size, cport);
+	gb_free(resp);
 }
 
 /**
@@ -196,39 +271,40 @@ static void gb_camera_configure_streams(uint16_t cport, struct gb_message *msg, 
  * @param msg- incoming gb message request
  * @param data- pointer to camera driver data
  */
-static void gb_camera_capture(uint16_t cport, struct gb_message *msg, const struct gb_camera_driver_data *data)
+static void gb_camera_capture(uint16_t cport, struct gb_message *msg,
+			      const struct gb_camera_driver_data *data)
 {
-    struct gb_camera_driver_data *drv_data = (struct gb_camera_driver_data *)data;
-    struct video_buffer *vbuf;
-    int ret;
+	struct gb_camera_driver_data *drv_data = (struct gb_camera_driver_data *)data;
+	struct video_buffer *vbuf;
+	int ret;
 
-    if (drv_data == NULL || drv_data->info.state < STATE_CONFIGURED) {
-        gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
-        return;
-    }
+	if (drv_data == NULL || drv_data->info.state < STATE_CONFIGURED) {
+		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
+		return;
+	}
 
-    if (drv_data->info.state != STATE_STREAMING) {
-        ret = video_stream_start(drv_data->dev, VIDEO_BUF_TYPE_OUTPUT);
-        if (ret) {
-            gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
-            return;
-        }
-        drv_data->info.state = STATE_STREAMING;
-    }
+	if (drv_data->info.state != STATE_STREAMING) {
+		ret = video_stream_start(drv_data->dev, VIDEO_BUF_TYPE_OUTPUT);
+		if (ret) {
+			gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
+			return;
+		}
+		drv_data->info.state = STATE_STREAMING;
+	}
 
-    ret = video_dequeue(drv_data->dev, &vbuf, K_MSEC(1000)); // Removed VIDEO_EP_OUT
-    if (ret) {
-        gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
-        return;
-    }
+	ret = video_dequeue(drv_data->dev, &vbuf, K_MSEC(1000)); // Removed VIDEO_EP_OUT
+	if (ret) {
+		gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
+		return;
+	}
 
-    /*TODO- Dynamically allocate gb response msg, copy vbuf->buffer 
-     *(size:vbuf->bytesused) into it send it back to the host */
+	/*TODO- Dynamically allocate gb response msg, copy vbuf->buffer
+	 *(size:vbuf->bytesused) into it send it back to the host */
 
-    video_enqueue(drv_data->dev, vbuf);
-  
-    /*stub: sending empty success until the payload packing is done */
-    gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
+	video_enqueue(drv_data->dev, vbuf);
+
+	/*stub: sending empty success until the payload packing is done */
+	gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
 }
 
 /**
@@ -237,22 +313,23 @@ static void gb_camera_capture(uint16_t cport, struct gb_message *msg, const stru
  * @param msg- incoming gb message request
  * @param data- Pointer to camera driver data
  */
-static void gb_camera_flush(uint16_t cport, struct gb_message *msg, const struct gb_camera_driver_data *data)
+static void gb_camera_flush(uint16_t cport, struct gb_message *msg,
+			    const struct gb_camera_driver_data *data)
 {
-    struct gb_camera_driver_data *drv_data = (struct gb_camera_driver_data *)data;
+	struct gb_camera_driver_data *drv_data = (struct gb_camera_driver_data *)data;
 
-    if (drv_data == NULL || drv_data->info.state < STATE_STREAMING) {
-        gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
-        return;
-    }
+	if (drv_data == NULL || drv_data->info.state < STATE_STREAMING) {
+		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
+		return;
+	}
 
-    video_stream_stop(drv_data->dev, VIDEO_BUF_TYPE_OUTPUT); 
+	video_stream_stop(drv_data->dev, VIDEO_BUF_TYPE_OUTPUT);
 
-    video_flush(drv_data->dev, true);
+	video_flush(drv_data->dev, true);
 
-    drv_data->info.state = STATE_CONFIGURED;
+	drv_data->info.state = STATE_CONFIGURED;
 
-    gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
+	gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
 }
 
 /**
@@ -312,15 +389,15 @@ static void gb_camera_handler(const void *priv, struct gb_message *msg, uint16_t
 	case GB_CAMERA_TYPE_CAPABILITIES:
 		gb_camera_capabilities(cport, msg, data);
 		break;
-  case GB_CAMERA_TYPE_CONFIGURE_STREAMS:
-    gb_camera_configure_streams(cport, msg, data);
-    break;
-   case GB_CAMERA_TYPE_CAPTURE:
-     gb_camera_capture(cport, msg, data);
-        break;
-    case GB_CAMERA_TYPE_FLUSH:
-        gb_camera_flush(cport, msg, data);
-        break;
+	case GB_CAMERA_TYPE_CONFIGURE_STREAMS:
+		gb_camera_configure_streams(cport, msg, data);
+		break;
+	case GB_CAMERA_TYPE_CAPTURE:
+		gb_camera_capture(cport, msg, data);
+		break;
+	case GB_CAMERA_TYPE_FLUSH:
+		gb_camera_flush(cport, msg, data);
+		break;
 	default:
 		LOG_ERR("Invalid type: %d", gb_message_type(msg));
 		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);

--- a/subsys/greybus/camera.c
+++ b/subsys/greybus/camera.c
@@ -176,7 +176,7 @@ static void gb_camera_configure_streams(uint16_t cport, struct gb_message *msg,
 	int ret, i;
 	uint8_t resp_flags = 0;
 
-	if (drv_data == NULL || drv_data->info.state < STATE_UNCONFIGURED) {
+	if (drv_data == NULL || drv_data->info.state == STATE_STREAMING) {
 		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
 		return;
 	}
@@ -228,6 +228,7 @@ static void gb_camera_configure_streams(uint16_t cport, struct gb_message *msg,
 		}
 
 		if (i == 0) {
+			hw_fmt.type = VIDEO_BUF_TYPE_OUTPUT;
 			hw_fmt.pixelformat = VIDEO_PIX_FMT_JPEG;
 			hw_fmt.width = req_width;
 			hw_fmt.height = req_height;

--- a/subsys/greybus/camera.c
+++ b/subsys/greybus/camera.c
@@ -65,7 +65,7 @@ LOG_MODULE_REGISTER(greybus_camera, CONFIG_GREYBUS_LOG_LEVEL);
  */
 static void gb_camera_protocol_version(uint16_t cport, struct gb_message *msg)
 {
-	struct gb_camera_version_response response = {
+	const struct gb_camera_version_response response = {
 		.major = GB_CAMERA_VERSION_MAJOR,
 		.minor = GB_CAMERA_VERSION_MINOR,
 	};
@@ -91,11 +91,10 @@ static void gb_camera_capabilities(uint16_t cport, struct gb_message *msg,
 				   const struct gb_camera_driver_data *data)
 {
 	struct gb_camera_capabilities_response *response;
-	struct video_caps vcaps = {0};
+	struct video_caps vcaps;
 	struct gb_camera_csi_params *csi_header;
 	struct gb_camera_format_desc *format;
-	size_t payload_size;
-	size_t total_size;
+	size_t payload_size, total_size;
 	uint8_t num_formats = 0;
 	int ret, i;
 
@@ -104,6 +103,7 @@ static void gb_camera_capabilities(uint16_t cport, struct gb_message *msg,
 		return;
 	}
 
+	vcaps.type = VIDEO_BUF_TYPE_OUTPUT;
 	ret = video_get_caps(data->dev, &vcaps);
 	if (ret) {
 		gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
@@ -181,15 +181,13 @@ static void gb_camera_configure_streams(uint16_t cport, struct gb_message *msg,
 		return;
 	}
 
-	payload_size = gb_hdr_message_len(&msg->header) - sizeof(struct gb_operation_msg_hdr);
-
+	payload_size = gb_message_payload_len(msg);
 	if (payload_size < sizeof(*req)) {
 		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
 		return;
 	}
 
 	req = (struct gb_camera_configure_streams_request *)msg->payload;
-
 	if (req->num_streams == 0 || req->num_streams > GB_CAMERA_MAX_STREAMS) {
 		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
 		return;
@@ -217,9 +215,7 @@ static void gb_camera_configure_streams(uint16_t cport, struct gb_message *msg,
 		req_format = sys_le16_to_cpu(stream_req->format);
 
 		if (req_width == 0 || req_height == 0) {
-			gb_free(resp);
-			gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
-			return;
+			goto err_invalid_stream;
 		}
 
 		if (req_format != GB_CAMERA_CAP_FMT_JPEG) {
@@ -264,6 +260,11 @@ static void gb_camera_configure_streams(uint16_t cport, struct gb_message *msg,
 
 	gb_transport_message_response_success_send(msg, resp, resp_size, cport);
 	gb_free(resp);
+	return;
+
+err_invalid_stream:
+	gb_free(resp);
+	gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
 }
 
 /**
@@ -286,7 +287,7 @@ static void gb_camera_capture(uint16_t cport, struct gb_message *msg,
 		return;
 	}
 
-	payload_size = gb_hdr_message_len(&msg->header) - sizeof(struct gb_operation_msg_hdr);
+	payload_size = gb_message_payload_len(msg);
 	if (payload_size != sizeof(*req)) {
 		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
 		return;
@@ -321,7 +322,7 @@ static void gb_camera_flush(uint16_t cport, struct gb_message *msg,
 			    const struct gb_camera_driver_data *data)
 {
 	struct gb_camera_driver_data *drv_data = (struct gb_camera_driver_data *)data;
-	struct gb_camera_flush_response *resp;
+	struct gb_camera_flush_response resp;
 	int ret;
 
 	if (drv_data == NULL || drv_data->info.state < STATE_STREAMING) {
@@ -343,25 +344,19 @@ static void gb_camera_flush(uint16_t cport, struct gb_message *msg,
 
 	drv_data->info.state = STATE_CONFIGURED;
 
-	resp = gb_alloc(sizeof(*resp));
-	if (!resp) {
-		gb_transport_message_empty_response_send(msg, GB_OP_NO_MEMORY, cport);
-		return;
-	}
-	memset(resp, 0, sizeof(*resp));
+	memset(&resp, 0, sizeof(resp));
 
 	/* TODO for Data CPort Architecture:
 	 * this request_id must be updated to track the ID of the last successfully
 	 * flushed capture request once the asynchronous data queue (mentioned before) is
 	 * implemented. Hardcoded to 0 for the MVP */
-	resp->request_id = sys_cpu_to_le32(0);
+	resp.request_id = sys_cpu_to_le32(0);
 
-	gb_transport_message_response_success_send(msg, resp, sizeof(*resp), cport);
-	gb_free(resp);
+	gb_transport_message_response_success_send(msg, &resp, sizeof(resp), cport);
 }
 
 /**
- * @brief Callback invoked when the greybus host connects to the cemra cport
+ * @brief Callback invoked when the greybus host connects to the camera cport
  * Initializes camera protocol state and binds the Zephyr video device.
  * @param priv- Private driver data pointer
  * @param cport- The CPort number that was connected.

--- a/subsys/greybus/camera.c
+++ b/subsys/greybus/camera.c
@@ -275,13 +275,24 @@ static void gb_camera_capture(uint16_t cport, struct gb_message *msg,
 			      const struct gb_camera_driver_data *data)
 {
 	struct gb_camera_driver_data *drv_data = (struct gb_camera_driver_data *)data;
-	struct video_buffer *vbuf;
+	struct gb_camera_capture_request *req;
+	size_t payload_size;
+	uint16_t num_frames;
 	int ret;
 
 	if (drv_data == NULL || drv_data->info.state < STATE_CONFIGURED) {
 		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
 		return;
 	}
+
+	payload_size = gb_hdr_message_len(&msg->header) - sizeof(struct gb_operation_msg_hdr);
+	if (payload_size != sizeof(*req)) {
+		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
+		return;
+	}
+
+	req = (struct gb_camera_capture_request *)msg->payload;
+	num_frames = sys_le16_to_cpu(req->num_frames);
 
 	if (drv_data->info.state != STATE_STREAMING) {
 		ret = video_stream_start(drv_data->dev, VIDEO_BUF_TYPE_OUTPUT);
@@ -292,18 +303,10 @@ static void gb_camera_capture(uint16_t cport, struct gb_message *msg,
 		drv_data->info.state = STATE_STREAMING;
 	}
 
-	ret = video_dequeue(drv_data->dev, &vbuf, K_MSEC(1000)); // Removed VIDEO_EP_OUT
-	if (ret) {
-		gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
-		return;
-	}
-
-	/*TODO- Dynamically allocate gb response msg, copy vbuf->buffer
-	 *(size:vbuf->bytesused) into it send it back to the host */
-
-	video_enqueue(drv_data->dev, vbuf);
-
-	/*stub: sending empty success until the payload packing is done */
+	/* TODO for Data CPort Architecture PR:
+	 * an asynchronous worker thread here to pull `num_frames`
+	 * from `video_dequeue()` and push them over the Data CPort
+	 */
 	gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
 }
 
@@ -317,19 +320,43 @@ static void gb_camera_flush(uint16_t cport, struct gb_message *msg,
 			    const struct gb_camera_driver_data *data)
 {
 	struct gb_camera_driver_data *drv_data = (struct gb_camera_driver_data *)data;
+	struct gb_camera_flush_response *resp;
+	int ret;
 
 	if (drv_data == NULL || drv_data->info.state < STATE_STREAMING) {
 		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
 		return;
 	}
 
-	video_stream_stop(drv_data->dev, VIDEO_BUF_TYPE_OUTPUT);
+	ret = video_stream_stop(drv_data->dev, VIDEO_BUF_TYPE_OUTPUT);
+	if (ret) {
+		gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
+		return;
+	}
 
-	video_flush(drv_data->dev, true);
+	ret = video_flush(drv_data->dev, true);
+	if (ret) {
+		gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
+		return;
+	}
 
 	drv_data->info.state = STATE_CONFIGURED;
 
-	gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
+	resp = gb_alloc(sizeof(*resp));
+	if (!resp) {
+		gb_transport_message_empty_response_send(msg, GB_OP_NO_MEMORY, cport);
+		return;
+	}
+	memset(resp, 0, sizeof(*resp));
+
+	/* TODO for Data CPort Architecture:
+	 * this request_id must be updated to track the ID of the last successfully
+	 * flushed capture request once the asynchronous data queue (mentioned before) is
+	 * implemented. Hardcoded to 0 for the MVP */
+	resp->request_id = sys_cpu_to_le32(0);
+
+	gb_transport_message_response_success_send(msg, resp, sizeof(*resp), cport);
+	gb_free(resp);
 }
 
 /**

--- a/subsys/greybus/camera.c
+++ b/subsys/greybus/camera.c
@@ -65,7 +65,7 @@ LOG_MODULE_REGISTER(greybus_camera, CONFIG_GREYBUS_LOG_LEVEL);
  */
 static void gb_camera_protocol_version(uint16_t cport, struct gb_message *msg)
 {
-	const struct gb_camera_version_response response = {
+	struct gb_camera_version_response response = {
 		.major = GB_CAMERA_VERSION_MAJOR,
 		.minor = GB_CAMERA_VERSION_MINOR,
 	};
@@ -91,10 +91,11 @@ static void gb_camera_capabilities(uint16_t cport, struct gb_message *msg,
 				   const struct gb_camera_driver_data *data)
 {
 	struct gb_camera_capabilities_response *response;
-	struct video_caps vcaps;
+	struct video_caps vcaps = {0};
 	struct gb_camera_csi_params *csi_header;
 	struct gb_camera_format_desc *format;
-	size_t payload_size, total_size;
+	size_t payload_size;
+	size_t total_size;
 	uint8_t num_formats = 0;
 	int ret, i;
 
@@ -103,7 +104,6 @@ static void gb_camera_capabilities(uint16_t cport, struct gb_message *msg,
 		return;
 	}
 
-	vcaps.type = VIDEO_BUF_TYPE_OUTPUT;
 	ret = video_get_caps(data->dev, &vcaps);
 	if (ret) {
 		gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
@@ -156,10 +156,110 @@ static void gb_camera_capabilities(uint16_t cport, struct gb_message *msg,
 }
 
 /**
+ * @brief Handler for the configure streams operation
+ * @param cport- the CPort number
+ * @param msg- incoming gb message request
+ * @param data- pointer to camera driver data
+ */
+static void gb_camera_configure_streams(uint16_t cport, struct gb_message *msg, const struct gb_camera_driver_data *data)
+{
+    struct gb_camera_driver_data *drv_data = (struct gb_camera_driver_data *)data;
+    struct video_format fmt;
+    int ret;
+
+    if (drv_data == NULL || drv_data->info.state < STATE_UNCONFIGURED) {
+        gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
+        return;
+    }
+
+    /*TODO- Parse the requested resolution from the incoming msg payload */
+    /*for now, we are hardcoding to a format that we know the driver supports */
+    fmt.pixelformat = VIDEO_PIX_FMT_JPEG;
+    fmt.width = 640;
+    fmt.height = 480;
+    fmt.pitch = 640 * 2; 
+
+    ret = video_set_format(drv_data->dev, &fmt);
+    if (ret) {
+        gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
+        return;
+    }
+
+    drv_data->info.state = STATE_CONFIGURED;
+
+    gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
+}
+
+/**
+ * @brief Handler for the capture operation.
+ * @param cport- the CPort number
+ * @param msg- incoming gb message request
+ * @param data- pointer to camera driver data
+ */
+static void gb_camera_capture(uint16_t cport, struct gb_message *msg, const struct gb_camera_driver_data *data)
+{
+    struct gb_camera_driver_data *drv_data = (struct gb_camera_driver_data *)data;
+    struct video_buffer *vbuf;
+    int ret;
+
+    if (drv_data == NULL || drv_data->info.state < STATE_CONFIGURED) {
+        gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
+        return;
+    }
+
+    if (drv_data->info.state != STATE_STREAMING) {
+        ret = video_stream_start(drv_data->dev, VIDEO_BUF_TYPE_OUTPUT);
+        if (ret) {
+            gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
+            return;
+        }
+        drv_data->info.state = STATE_STREAMING;
+    }
+
+    ret = video_dequeue(drv_data->dev, &vbuf, K_MSEC(1000)); // Removed VIDEO_EP_OUT
+    if (ret) {
+        gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
+        return;
+    }
+
+    /*TODO- Dynamically allocate gb response msg, copy vbuf->buffer 
+     *(size:vbuf->bytesused) into it send it back to the host */
+
+    video_enqueue(drv_data->dev, vbuf);
+  
+    /*stub: sending empty success until the payload packing is done */
+    gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
+}
+
+/**
+ * @brief Handler for the flush operation
+ * @param cport- the CPort number
+ * @param msg- incoming gb message request
+ * @param data- Pointer to camera driver data
+ */
+static void gb_camera_flush(uint16_t cport, struct gb_message *msg, const struct gb_camera_driver_data *data)
+{
+    struct gb_camera_driver_data *drv_data = (struct gb_camera_driver_data *)data;
+
+    if (drv_data == NULL || drv_data->info.state < STATE_STREAMING) {
+        gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
+        return;
+    }
+
+    video_stream_stop(drv_data->dev, VIDEO_BUF_TYPE_OUTPUT); 
+
+    video_flush(drv_data->dev, true);
+
+    drv_data->info.state = STATE_CONFIGURED;
+
+    gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
+}
+
+/**
  * @brief Callback invoked when the greybus host connects to the cemra cport
  * Initializes camera protocol state and binds the Zephyr video device.
  * @param priv- Private driver data pointer
- * @param cport= The CPort number that was connected.
+ * @param cport- The CPort number that was connected.
  */
 static void gb_camera_connected(const void *priv, uint16_t cport)
 {
@@ -212,6 +312,15 @@ static void gb_camera_handler(const void *priv, struct gb_message *msg, uint16_t
 	case GB_CAMERA_TYPE_CAPABILITIES:
 		gb_camera_capabilities(cport, msg, data);
 		break;
+  case GB_CAMERA_TYPE_CONFIGURE_STREAMS:
+    gb_camera_configure_streams(cport, msg, data);
+    break;
+   case GB_CAMERA_TYPE_CAPTURE:
+     gb_camera_capture(cport, msg, data);
+        break;
+    case GB_CAMERA_TYPE_FLUSH:
+        gb_camera_flush(cport, msg, data);
+        break;
 	default:
 		LOG_ERR("Invalid type: %d", gb_message_type(msg));
 		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);

--- a/tests/greybus/integration/camera/src/main.c
+++ b/tests/greybus/integration/camera/src/main.c
@@ -1,37 +1,200 @@
+/*
+ * Copyright (c) 2026 Pavithra CP, BeagleBoard.org
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <greybus/greybus_messages.h>
+#include <greybus/greybus_protocols.h>
+#include <greybus/greybus.h>
 #include <zephyr/ztest.h>
-#include <zephyr/drivers/video.h>
+#include <zephyr/kernel.h>
 #include <zephyr/device.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/fff.h>
 
-#define VBUF_SIZE 1024
+DEFINE_FFF_GLOBALS;
+LOG_MODULE_REGISTER(greybus_camera_test, CONFIG_GREYBUS_LOG_LEVEL);
 
-static struct video_buffer *vbuf;
+struct gb_msg_with_cport gb_transport_get_message(void);
 
-ZTEST(camera_suite, test_camera_device_ready)
+static const int camera_cport = 1;
+
+static void *camera_setup(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_ALIAS(camera0));
-	zassert_true(device_is_ready(dev), "Camera device not ready");
+	struct gb_msg_with_cport resp;
+	struct gb_control_version_request *ver_req;
+	struct gb_message *msg;
+
+	msg = gb_message_request_alloc(sizeof(*ver_req), GB_CONTROL_TYPE_VERSION, false);
+	ver_req = (struct gb_control_version_request *)msg->payload;
+	ver_req->major = 0;
+	ver_req->minor = 1;
+
+	greybus_rx_handler(0, msg);
+	resp = gb_transport_get_message();
+	zassert_not_null(resp.msg, "No version response received");
+	zassert_true(gb_message_is_success(resp.msg), "Version Handshake failed");
+
+	gb_message_dealloc(resp.msg);
+	return NULL;
 }
 
-ZTEST(camera_suite, test_camera_frame_capture)
+ZTEST_SUITE(greybus_camera_tests, NULL, camera_setup, NULL, NULL, NULL);
+
+ZTEST(greybus_camera_tests, test_attempt_premature_capture)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_ALIAS(camera0));
-	struct video_buffer *rx_buf;
-	int err;
+	struct gb_msg_with_cport resp;
+	struct gb_message *req;
+	struct gb_camera_capture_request *cap_req;
 
-	vbuf = video_buffer_alloc(VBUF_SIZE, K_NO_WAIT);
-	zassert_not_null(vbuf, "Failed to allocate video buffer");
+	req = gb_message_request_alloc(sizeof(*cap_req), GB_CAMERA_TYPE_CAPTURE, false);
+	cap_req = (struct gb_camera_capture_request *)req->payload;
+	cap_req->num_frames = sys_cpu_to_le16(1);
 
-	vbuf->type = VIDEO_BUF_TYPE_OUTPUT;
+	greybus_rx_handler(camera_cport, req);
+	resp = gb_transport_get_message();
 
-	video_enqueue(dev, vbuf);
-	video_stream_start(dev, VIDEO_BUF_TYPE_OUTPUT);
+	zassert_not_null(resp.msg, "No capture response received");
+	zassert_equal(resp.msg->header.result, GB_OP_INVALID,
+		      "Expected GB_OP_INVALID for premature capture, got: %d",
+		      resp.msg->header.result);
 
-	err = video_dequeue(dev, &rx_buf, K_MSEC(500));
-	zassert_equal(err, 0, "Failed to dequeue (err: %d)", err);
-	zassert_equal(rx_buf->bytesused, VBUF_SIZE, "Wrong frame size");
-
-	video_stream_stop(dev, VIDEO_BUF_TYPE_OUTPUT);
-	video_buffer_release(vbuf);
+	gb_message_dealloc(resp.msg);
 }
 
-ZTEST_SUITE(camera_suite, NULL, NULL, NULL, NULL, NULL);
+/*note that the tests are named as such to conincidentally follow the lexicographic order right now
+ */
+ZTEST(greybus_camera_tests, test_bad_configure_zero_res)
+{
+	struct gb_message *req;
+	struct gb_msg_with_cport resp;
+	struct gb_camera_configure_streams_request *cfg_req;
+	size_t payload_size = sizeof(*cfg_req) + sizeof(struct gb_camera_stream_config_request);
+
+	req = gb_message_request_alloc(payload_size, GB_CAMERA_TYPE_CONFIGURE_STREAMS, false);
+	cfg_req = (struct gb_camera_configure_streams_request *)req->payload;
+	cfg_req->num_streams = 1;
+	cfg_req->config[0].width = sys_cpu_to_le16(0);
+	cfg_req->config[0].height = sys_cpu_to_le16(480);
+
+	greybus_rx_handler(camera_cport, req);
+	resp = gb_transport_get_message();
+
+	zassert_not_null(resp.msg, "No config response received");
+	zassert_equal(resp.msg->header.result, GB_OP_INVALID,
+		      "Expected GB_OP_INVALID for 0x480 resolution, got: %d",
+		      resp.msg->header.result);
+
+	gb_message_dealloc(resp.msg);
+}
+
+ZTEST(greybus_camera_tests, test_configure_valid)
+{
+	struct gb_message *req;
+	struct gb_msg_with_cport resp;
+	struct gb_camera_configure_streams_request *cfg_req;
+
+	size_t payload_size = sizeof(struct gb_camera_configure_streams_request) +
+			      sizeof(struct gb_camera_stream_config_request);
+
+	req = gb_message_request_alloc(payload_size, GB_CAMERA_TYPE_CONFIGURE_STREAMS, false);
+	cfg_req = (struct gb_camera_configure_streams_request *)req->payload;
+	cfg_req->num_streams = 1;
+
+	cfg_req->config[0].width = sys_cpu_to_le16(640);
+	cfg_req->config[0].height = sys_cpu_to_le16(480);
+	cfg_req->config[0].format = sys_cpu_to_le16(1);
+
+	greybus_rx_handler(camera_cport, req);
+	resp = gb_transport_get_message();
+
+	zassert_not_null(resp.msg, "No config response received");
+	zassert_true(gb_message_is_success(resp.msg), "Valid Config failed: %d",
+		     resp.msg->header.result);
+
+	gb_message_dealloc(resp.msg);
+}
+
+ZTEST(greybus_camera_tests, test_flush_prematurely)
+{
+	struct gb_msg_with_cport resp;
+	struct gb_message *req;
+
+	req = gb_message_request_alloc(0, GB_CAMERA_TYPE_FLUSH, false);
+
+	greybus_rx_handler(camera_cport, req);
+	resp = gb_transport_get_message();
+
+	zassert_not_null(resp.msg, "No flush response received");
+	zassert_equal(resp.msg->header.result, GB_OP_INVALID,
+		      "Expected GB_OP_INVALID for premature flush, got: %d",
+		      resp.msg->header.result);
+
+	gb_message_dealloc(resp.msg);
+}
+
+ZTEST(greybus_camera_tests, test_garbage_capture_payload)
+{
+	struct gb_msg_with_cport resp;
+	struct gb_message *req;
+	struct gb_camera_capture_request *cap_req;
+
+	size_t bad_payload_size = sizeof(*cap_req) + 1;
+
+	req = gb_message_request_alloc(bad_payload_size, GB_CAMERA_TYPE_CAPTURE, false);
+	cap_req = (struct gb_camera_capture_request *)req->payload;
+	cap_req->num_frames = sys_cpu_to_le16(1);
+
+	greybus_rx_handler(camera_cport, req);
+	resp = gb_transport_get_message();
+
+	zassert_not_null(resp.msg, "No capture response received");
+	zassert_equal(resp.msg->header.result, GB_OP_INVALID,
+		      "Expected GB_OP_INVALID for malformed payload, got: %d",
+		      resp.msg->header.result);
+
+	gb_message_dealloc(resp.msg);
+}
+
+ZTEST(greybus_camera_tests, test_valid_capture)
+{
+	struct gb_msg_with_cport resp;
+	struct gb_message *req;
+	struct gb_camera_capture_request *cap_req;
+
+	req = gb_message_request_alloc(sizeof(*cap_req), GB_CAMERA_TYPE_CAPTURE, false);
+	cap_req = (struct gb_camera_capture_request *)req->payload;
+	cap_req->num_frames = sys_cpu_to_le16(10);
+
+	greybus_rx_handler(camera_cport, req);
+	resp = gb_transport_get_message();
+
+	zassert_not_null(resp.msg, "No capture response received");
+	zassert_true(gb_message_is_success(resp.msg), "Valid Capture failed: %d",
+		     resp.msg->header.result);
+
+	gb_message_dealloc(resp.msg);
+}
+
+ZTEST(greybus_camera_tests, test_valid_flush)
+{
+	struct gb_msg_with_cport resp;
+	struct gb_message *req;
+	const struct gb_camera_flush_response *flush_resp;
+
+	req = gb_message_request_alloc(0, GB_CAMERA_TYPE_FLUSH, false);
+
+	greybus_rx_handler(camera_cport, req);
+	resp = gb_transport_get_message();
+
+	zassert_not_null(resp.msg, "No flush response received");
+	zassert_true(gb_message_is_success(resp.msg), "Valid Flush failed: %d",
+		     resp.msg->header.result);
+
+	flush_resp = (struct gb_camera_flush_response *)resp.msg->payload;
+	zassert_equal(flush_resp->request_id, sys_cpu_to_le32(0),
+		      "Expected stubbed request_id of 0");
+
+	gb_message_dealloc(resp.msg);
+}


### PR DESCRIPTION
This PR introduces the foundational streaming architecture for the Camera protocol.

### Key Changes
- **Operation Handlers:** Implemented skeleton handlers for `GB_CAMERA_TYPE_CONFIGURE_STREAMS`, `GB_CAMERA_TYPE_CAPTURE`, and `GB_CAMERA_TYPE_FLUSH`
- **Zephyr API Integration:** Connected the handlers to the underlying hardware driver using `video_set_format`, `video_stream_start`, `video_dequeue`, `video_enqueue`, `video_stream_stop`, and `video_flush`
- **State Management:** Updated the internal camera state machine to safely track and implement the stream lifecycle

### TODO s
- [ ] Configure `VIDEO_BUFFER_POOL` in the test suite `prj.conf` to allocate memory for the fake-camera frame generation.
- [x] Implement Greybus payload unpacking and format translation in `gb_camera_configure_streams`.
- [ ] Implement dynamic Greybus payload packing 