### PR TITLE
subsys: camera: migrate to new video_driver_flush API

### DIFF
--- a/subsys/greybus/camera.c
+++ b/subsys/greybus/camera.c
@@ -336,7 +336,7 @@ static void gb_camera_flush(uint16_t cport, struct gb_message *msg,
 		return;
 	}
 
-	ret = video_flush(drv_data->dev, true);
+	ret = video_driver_flush(drv_data->dev, true);
 	if (ret) {
 		gb_transport_message_empty_response_send(msg, GB_OP_UNKNOWN_ERROR, cport);
 		return;


### PR DESCRIPTION
Upstream Zephyr recently renamed the video_flush API to `video_driver_flush` in `<zephyr/drivers/video.h>`. This commit updates the greybus camera subsystem to match the new API and restore the CI pipeline. The CI pipeline was breaking without this, hence a new PR was created for just this particular hotfix.