### PR TITLE
audio: Implement Greybus Audio Teardown, Events, and Power Management

### DIFF
--- a/subsys/greybus/audio.c
+++ b/subsys/greybus/audio.c
@@ -349,13 +349,58 @@ static void gb_audio_deactivate_rx(uint16_t cport, struct gb_message *msg,
 		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
 		return;
 	}
-
 	/*
 	 * Zephyr's codec API currently lacks audio_codec_stop_input()
 	 */
 	LOG_INF("RX stream deactivated");
 
 	gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
+}
+
+/*
+ * Proactively notify the linux host that a physical jack was inserted or removed
+ * Note- the return types here are int as we are sending the event to zephyr host
+ */
+int gb_audio_send_jack_event(uint16_t cport, uint8_t widget_id, uint8_t jack_attribute,
+			     uint8_t event)
+{
+	struct gb_message *msg;
+	struct gb_audio_jack_event_request *req;
+
+	msg = gb_message_request_alloc(sizeof(struct gb_audio_jack_event_request),
+				       GB_AUDIO_TYPE_JACK_EVENT, false);
+	if (!msg) {
+		LOG_ERR("Failed to allocate JACK_EVENT message");
+		return -ENOMEM;
+	}
+
+	req = (struct gb_audio_jack_event_request *)msg->payload;
+	req->widget_id = widget_id;
+	req->jack_attribute = jack_attribute;
+	req->event = event;
+
+	/* Send the event to the Linux host */
+	return gb_transport_message_send(msg, cport);
+}
+
+int gb_audio_send_button_event(uint16_t cport, uint8_t widget_id, uint8_t button_id, uint8_t event)
+{
+	struct gb_message *msg;
+	struct gb_audio_button_event_request *req;
+
+	msg = gb_message_request_alloc(sizeof(struct gb_audio_button_event_request),
+				       GB_AUDIO_TYPE_BUTTON_EVENT, false);
+	if (!msg) {
+		LOG_ERR("Failed to allocate BUTTON_EVENT message");
+		return -ENOMEM;
+	}
+
+	req = (struct gb_audio_button_event_request *)msg->payload;
+	req->widget_id = widget_id;
+	req->button_id = button_id;
+	req->event = event;
+
+	return gb_transport_message_send(msg, cport);
 }
 
 static void gb_audio_handler(const void *priv, struct gb_message *msg, uint16_t cport)

--- a/subsys/greybus/audio.c
+++ b/subsys/greybus/audio.c
@@ -403,6 +403,22 @@ int gb_audio_send_button_event(uint16_t cport, uint8_t widget_id, uint8_t button
 	return gb_transport_message_send(msg, cport);
 }
 
+// These are sort of stubs for hardware migration. In a real hardware, this turns on and off the
+// amplifier power rail
+static void gb_audio_enable_widget(uint16_t cport, struct gb_message *msg,
+				   struct gb_audio_driver_data *data)
+{
+	LOG_INF("Widget enabled by host");
+	gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
+}
+
+static void gb_audio_disable_widget(uint16_t cport, struct gb_message *msg,
+				    struct gb_audio_driver_data *data)
+{
+	LOG_INF("Widget disabled by host");
+	gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
+}
+
 static void gb_audio_handler(const void *priv, struct gb_message *msg, uint16_t cport)
 {
 	const struct gb_audio_driver_data *data = priv;
@@ -438,6 +454,12 @@ static void gb_audio_handler(const void *priv, struct gb_message *msg, uint16_t 
 		break;
 	case GB_AUDIO_TYPE_DEACTIVATE_RX:
 		gb_audio_deactivate_rx(cport, msg, (struct gb_audio_driver_data *)data);
+		break;
+	case GB_AUDIO_TYPE_ENABLE_WIDGET:
+		gb_audio_enable_widget(cport, msg, (struct gb_audio_driver_data *)data);
+		break;
+	case GB_AUDIO_TYPE_DISABLE_WIDGET:
+		gb_audio_disable_widget(cport, msg, (struct gb_audio_driver_data *)data);
 		break;
 	default:
 		LOG_ERR("Invalid type: %d", gb_message_type(msg));

--- a/subsys/greybus/audio.c
+++ b/subsys/greybus/audio.c
@@ -326,6 +326,38 @@ static void gb_audio_send_data(uint16_t cport, struct gb_message *msg,
 	gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
 }
 
+static void gb_audio_deactivate_tx(uint16_t cport, struct gb_message *msg,
+				   struct gb_audio_driver_data *data)
+{
+	if (data == NULL || data->info.state != STATE_CONFIGURED) {
+		LOG_ERR("Cannot deactivate TX stream: PCM not configured");
+		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
+		return;
+	}
+
+	audio_codec_stop_output(data->dev);
+
+	LOG_INF("TX stream deactivated");
+	gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
+}
+
+static void gb_audio_deactivate_rx(uint16_t cport, struct gb_message *msg,
+				   struct gb_audio_driver_data *data)
+{
+	if (data == NULL || data->info.state != STATE_CONFIGURED) {
+		LOG_ERR("Cannot deactivate RX stream: PCM not configured");
+		gb_transport_message_empty_response_send(msg, GB_OP_INVALID, cport);
+		return;
+	}
+
+	/*
+	 * Zephyr's codec API currently lacks audio_codec_stop_input()
+	 */
+	LOG_INF("RX stream deactivated");
+
+	gb_transport_message_empty_response_send(msg, GB_OP_SUCCESS, cport);
+}
+
 static void gb_audio_handler(const void *priv, struct gb_message *msg, uint16_t cport)
 {
 	const struct gb_audio_driver_data *data = priv;
@@ -355,6 +387,12 @@ static void gb_audio_handler(const void *priv, struct gb_message *msg, uint16_t 
 		break;
 	case GB_AUDIO_TYPE_SEND_DATA:
 		gb_audio_send_data(cport, msg, (struct gb_audio_driver_data *)data);
+		break;
+	case GB_AUDIO_TYPE_DEACTIVATE_TX:
+		gb_audio_deactivate_tx(cport, msg, (struct gb_audio_driver_data *)data);
+		break;
+	case GB_AUDIO_TYPE_DEACTIVATE_RX:
+		gb_audio_deactivate_rx(cport, msg, (struct gb_audio_driver_data *)data);
 		break;
 	default:
 		LOG_ERR("Invalid type: %d", gb_message_type(msg));

--- a/subsys/greybus/greybus_audio.h
+++ b/subsys/greybus/greybus_audio.h
@@ -30,4 +30,10 @@ struct gb_audio_version_response {
 
 extern const struct gb_driver gb_audio_driver;
 
+/* Helpers for asynchronous events */
+int gb_audio_send_jack_event(uint16_t cport, uint8_t widget_id, uint8_t jack_attribute,
+			     uint8_t event);
+
+int gb_audio_send_button_event(uint16_t cport, uint8_t widget_id, uint8_t button_id, uint8_t event);
+
 #endif /*__GREYBUS_AUDIO_H__*/

--- a/tests/greybus/integration/audio/src/test_protocol.c
+++ b/tests/greybus/integration/audio/src/test_protocol.c
@@ -232,3 +232,22 @@ ZTEST(audio_protocol_tests, test_audio_deactivate_rx)
 	zassert_equal(drv_data.info.state, STATE_CONFIGURED,
 		      "State should remain STATE_CONFIGURED after DEACTIVATE_RX");
 }
+
+ZTEST(audio_protocol_tests, test_audio_jack_event)
+{
+	int ret;
+	/* simulating a headphone insertion into widget ID 4 */
+	ret = gb_audio_send_jack_event(TEST_CPORT, 4, GB_AUDIO_JACK_HEADPHONE,
+				       GB_AUDIO_JACK_EVENT_INSERTION);
+
+	zassert_equal(ret, -42, "Expected transport error -42 due to missing backend");
+}
+
+ZTEST(audio_protocol_tests, test_audio_button_event)
+{
+	int ret;
+	/*Simulating pressing the ID 1 (play/pause) */
+	ret = gb_audio_send_button_event(TEST_CPORT, 4, 1, GB_AUDIO_BUTTON_EVENT_PRESS);
+	// since native_sim lacks a physical transport backend
+	zassert_equal(ret, -42, "Expected transport error -42 due to missing backend");
+}

--- a/tests/greybus/integration/audio/src/test_protocol.c
+++ b/tests/greybus/integration/audio/src/test_protocol.c
@@ -251,3 +251,28 @@ ZTEST(audio_protocol_tests, test_audio_button_event)
 	// since native_sim lacks a physical transport backend
 	zassert_equal(ret, -42, "Expected transport error -42 due to missing backend");
 }
+
+ZTEST(audio_protocol_tests, test_audio_enable_widget)
+{
+	struct gb_audio_driver_data drv_data = {0};
+	gb_audio_driver.connected(&drv_data, TEST_CPORT);
+
+	struct gb_message *msg = gb_message_request_alloc(
+		sizeof(struct gb_audio_enable_widget_request), GB_AUDIO_TYPE_ENABLE_WIDGET, false);
+	zassert_not_null(msg, "Failed to allocate ENABLE_WIDGET message");
+
+	gb_audio_driver.op_handler(&drv_data, msg, TEST_CPORT);
+}
+
+ZTEST(audio_protocol_tests, test_audio_disable_widget)
+{
+	struct gb_audio_driver_data drv_data = {0};
+	gb_audio_driver.connected(&drv_data, TEST_CPORT);
+
+	struct gb_message *msg =
+		gb_message_request_alloc(sizeof(struct gb_audio_disable_widget_request),
+					 GB_AUDIO_TYPE_DISABLE_WIDGET, false);
+	zassert_not_null(msg, "Failed to allocate DISABLE_WIDGET message");
+
+	gb_audio_driver.op_handler(&drv_data, msg, TEST_CPORT);
+}

--- a/tests/greybus/integration/audio/src/test_protocol.c
+++ b/tests/greybus/integration/audio/src/test_protocol.c
@@ -198,3 +198,37 @@ ZTEST(audio_protocol_tests, test_audio_send_data_configured)
 	zassert_equal(drv_data.info.state, STATE_CONFIGURED,
 		      "State should remain STATE_CONFIGURED after successful SEND_DATA");
 }
+
+ZTEST(audio_protocol_tests, test_audio_deactivate_tx)
+{
+	struct gb_audio_driver_data drv_data = {0};
+	gb_audio_driver.connected(&drv_data, TEST_CPORT);
+
+	drv_data.info.state = STATE_CONFIGURED;
+
+	struct gb_message *msg = gb_message_request_alloc(
+		sizeof(struct gb_audio_deactivate_tx_request), GB_AUDIO_TYPE_DEACTIVATE_TX, false);
+	zassert_not_null(msg, "Failed to allocate DEACTIVATE_TX message");
+
+	gb_audio_driver.op_handler(&drv_data, msg, TEST_CPORT);
+
+	zassert_equal(drv_data.info.state, STATE_CONFIGURED,
+		      "State should remain STATE_CONFIGURED after DEACTIVATE_TX");
+}
+
+ZTEST(audio_protocol_tests, test_audio_deactivate_rx)
+{
+	struct gb_audio_driver_data drv_data = {0};
+	gb_audio_driver.connected(&drv_data, TEST_CPORT);
+
+	drv_data.info.state = STATE_CONFIGURED;
+
+	struct gb_message *msg = gb_message_request_alloc(
+		sizeof(struct gb_audio_deactivate_rx_request), GB_AUDIO_TYPE_DEACTIVATE_RX, false);
+	zassert_not_null(msg, "Failed to allocate DEACTIVATE_RX message");
+
+	gb_audio_driver.op_handler(&drv_data, msg, TEST_CPORT);
+
+	zassert_equal(drv_data.info.state, STATE_CONFIGURED,
+		      "State should remain STATE_CONFIGURED after DEACTIVATE_RX");
+}


### PR DESCRIPTION
Key Additions:

 - Stream Teardown (`DEACTIVATE_TX` / `DEACTIVATE_RX`): to simulate power savings

   - Asynchronous Events (`JACK_EVENT` / `BUTTON_EVENT`): Added helper functions (`gb_audio_send_jack_event`, `gb_audio_send_button_event`) that allow the Zephyr hardware driver to notify the ALSA host of physical jack insertions or media button presses

   - Widget Power Management (ENABLE_WIDGET / DISABLE_WIDGET): These will map to physical amplifier GPIO rails during hardware migration.

   - Testing: Expanded the ztest suite in` test_protocol.c` for coverage of the new teardown and event logic

**With this PR merged, the native_sim Greybus Audio mock is functionally complete. The next phase will involve hardware migration**